### PR TITLE
Allow (forward-)partial wildcard addresses

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -121,7 +121,7 @@ function getWildcardAddresses(username, domain) {
   if (typeof username !== 'string' || typeof domain !== 'string') return [];
   let result = [];
   // <= generates the 'simple' wildcard (a la '*@') address.
-  for (var i = 1; i <= username.length; i++) {
+  for (let i = 1; i <= username.length; i++) {
     result.push('*' + username.substr(i) + '@' + domain);
   }
   return result;

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -108,6 +108,25 @@ function normalizeAddress(address, withNames, options) {
     return addr;
 }
 
+/**
+ * Generate a list of possible wildcard addresses by generating all posible
+ * substrings of the username email address part.
+ *
+ * @param {String} username - The username part of the email address.
+ * @param {String} domain - The domain part of the email address.
+ * @return {Array} The list of all possible username wildcard addresses,
+ *   that would match this email address (as given by the params).
+ */
+function getWildcardAddresses(username, domain) {
+  if (typeof username !== 'string' || typeof domain !== 'string') return [];
+  let result = [];
+  // <= generates the 'simple' wildcard (a la '*@') address.
+  for (var i = 1; i <= username.length; i++) {
+    result.push('*' + username.substr(i) + '@' + domain);
+  }
+  return result;
+}
+
 // returns a redis config object with a retry strategy
 function redisConfig(defaultConfig) {
     return defaultConfig;
@@ -430,6 +449,7 @@ function uview(address) {
 module.exports = {
     normalizeAddress,
     normalizeDomain,
+    getWildcardAddresses,
     redisConfig,
     checkRangeQuery,
     decodeAddresses,

--- a/lib/user-handler.js
+++ b/lib/user-handler.js
@@ -136,7 +136,7 @@ class UserHandler {
                   username,
                   aliasDomain
                 );
-                query.addrview['$in'] = query.addrview['$in'].concat(_aliasWildcards);
+                query.addrview.$in = query.addrview.$in.concat(_aliasWildcards);
             }
 
             // try to find a catch-all address

--- a/lib/user-handler.js
+++ b/lib/user-handler.js
@@ -121,13 +121,22 @@ class UserHandler {
                 return false;
             }
 
+            let _partialWildcards = tools.getWildcardAddresses(
+              username,
+              domain
+            );
+
             let query = {
-                addrview: '*@' + domain
+                addrview: { $in: _partialWildcards }
             };
 
             if (aliasDomain) {
                 // search for alias domain as well
-                query.addrview = { $in: [query.addrview, '*@' + aliasDomain] };
+                let _aliasWildcards = tools.getWildcardAddresses(
+                  username,
+                  aliasDomain
+                );
+                query.addrview['$in'] = query.addrview['$in'].concat(_aliasWildcards);
             }
 
             // try to find a catch-all address


### PR DESCRIPTION
**Description**
This PR implements recognition of forward-partial wildcard addresses à la
`*_somestring@domain.com`. This means the user can receive mail for any address ending in `..._somestring@domain.com` by just adding the wildcard address `*_somestring@domain.com` to his account.

This was originally implemented in #119, which mixed the feature with further code refactoring.