### PR TITLE
404 code to 200 code with an error code string

### DIFF
--- a/lib/api/filters.js
+++ b/lib/api/filters.js
@@ -475,9 +475,9 @@ module.exports = (db, server) => {
             }
 
             if (!r.deletedCount) {
-                res.status(404);
                 res.json({
-                    error: 'Filter was not found'
+                    error: 'Filter was not found',
+                    code: 'FilterNotFound'
                 });
                 return next();
             }

--- a/lib/api/filters.js
+++ b/lib/api/filters.js
@@ -475,6 +475,7 @@ module.exports = (db, server) => {
             }
 
             if (!r.deletedCount) {
+                res.status(404);
                 res.json({
                     error: 'Filter was not found',
                     code: 'FilterNotFound'


### PR DESCRIPTION
404 error without an error code string is inconsistent when compared to all other methods. While on that topic, is there any reason for not using the right http response codes?

Sorry for all the issues 😁. Knowing me there's more to come. I'll get on the SHA password encryption as soon as I get my application working enough.