### PR TITLE
Fix missing addrview error

### DIFF
--- a/lib/user-handler.js
+++ b/lib/user-handler.js
@@ -132,6 +132,9 @@ class UserHandler {
                 return false;
             }
 
+            // Add addrview to projection as we will need it down further for
+            // matching the right wildcard partial address.
+            projection['addrview'] = true;
             let partialWildcards = tools.getWildcardAddresses(username, domain);
 
             let query = {


### PR DESCRIPTION
ZoneMTA wildduck plugin uses wildduck's user handler for address resolution.
A missing field in the projections map caused envelop from addresses in outgoing messages that matched a wildcard address of the user to be rejected by ZoneMTA wildduck plugin because of the error thrown in the user handler of wildduck.

The user handler makes use of `addrview` on [line 166](https://github.com/nodemailer/wildduck/blob/master/lib/user-handler.js#L166).