### PR TITLE
Allow prefix-partial wildcard addresses

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -126,6 +126,7 @@ function getWildcardAddresses(username, domain) {
     // <= generates the 'simple' wildcard (a la '*@') address.
     for (let i = 1; i < Math.min(username.length, consts.MAX_ALLOWED_WILDCARD_LENGTH) + 1; i++) {
         result.unshift('*' + username.substr(-i) + '@' + domain);
+        result.unshift(username.substr(0,i) + '*@' + domain);
     }
 
     return result;


### PR DESCRIPTION
### Description
This PR implements recognition of prefix-partial wildcard addresses à la
someprefix-\*@domain.com. This means the user can receive mail for any address starting in someprefix...@domain.com by just adding the wildcard address someprefix*@domain.com to his account.

### Computional complexity
This commit doubles the amount of wildcard addresses, that are generated for matching purposes. It will, however, never generate more addresses than double the amount of `MAX_ALLOWED_WILDCARD_LENGTH`.