### PR TITLE
Allow disabling forwarder

### DIFF
--- a/docs/api/api_data.js
+++ b/docs/api/api_data.js
@@ -577,6 +577,13 @@ define({ "api": [
           },
           {
             "group": "Success 200",
+            "type": "Boolean",
+            "optional": false,
+            "field": "results.forwardedDisabled",
+            "description": "<p>If true then the forwarded address is disabled</p>"
+          },
+          {
+            "group": "Success 200",
             "type": "String[]",
             "optional": true,
             "field": "results.target",
@@ -787,8 +794,15 @@ define({ "api": [
             "group": "Success 200",
             "type": "String[]",
             "optional": false,
-            "field": "results.tags",
+            "field": "tags",
             "description": "<p>List of tags associated with the Address</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Boolean",
+            "optional": false,
+            "field": "forwardedDisabled",
+            "description": "<p>If true then the forwarded address is disabled</p>"
           }
         ]
       },
@@ -1492,6 +1506,13 @@ define({ "api": [
             "optional": true,
             "field": "tags",
             "description": "<p>A list of tags associated with this address</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Boolean",
+            "optional": true,
+            "field": "forwardedDisabled",
+            "description": "<p>If true then disables forwarded address (stops forwarding messages)</p>"
           },
           {
             "group": "Parameter",

--- a/docs/api/api_data.json
+++ b/docs/api/api_data.json
@@ -577,6 +577,13 @@
           },
           {
             "group": "Success 200",
+            "type": "Boolean",
+            "optional": false,
+            "field": "results.forwardedDisabled",
+            "description": "<p>If true then the forwarded address is disabled</p>"
+          },
+          {
+            "group": "Success 200",
             "type": "String[]",
             "optional": true,
             "field": "results.target",
@@ -787,8 +794,15 @@
             "group": "Success 200",
             "type": "String[]",
             "optional": false,
-            "field": "results.tags",
+            "field": "tags",
             "description": "<p>List of tags associated with the Address</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Boolean",
+            "optional": false,
+            "field": "forwardedDisabled",
+            "description": "<p>If true then the forwarded address is disabled</p>"
           }
         ]
       },
@@ -1492,6 +1506,13 @@
             "optional": true,
             "field": "tags",
             "description": "<p>A list of tags associated with this address</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "Boolean",
+            "optional": true,
+            "field": "forwardedDisabled",
+            "description": "<p>If true then disables forwarded address (stops forwarding messages)</p>"
           },
           {
             "group": "Parameter",

--- a/docs/api/api_project.js
+++ b/docs/api/api_project.js
@@ -9,7 +9,7 @@ define({
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2020-05-08T07:54:54.784Z",
+    "time": "2020-05-08T12:34:11.199Z",
     "url": "http://apidocjs.com",
     "version": "0.22.1"
   }

--- a/docs/api/api_project.json
+++ b/docs/api/api_project.json
@@ -9,7 +9,7 @@
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2020-05-08T07:54:54.784Z",
+    "time": "2020-05-08T12:34:11.199Z",
     "url": "http://apidocjs.com",
     "version": "0.22.1"
   }

--- a/lib/api/addresses.js
+++ b/lib/api/addresses.js
@@ -40,6 +40,7 @@ module.exports = (db, server, userHandler) => {
      * @apiSuccess {String} results.address E-mail address string
      * @apiSuccess {String} results.user User ID this address belongs to if this is a User address
      * @apiSuccess {Boolean} results.forwarded If true then it is a forwarded address
+     * @apiSuccess {Boolean} results.forwardedDisabled If true then the forwarded address is disabled
      * @apiSuccess {String[]} [results.target] List of forwarding targets
      *
      * @apiError error Description of the error
@@ -194,7 +195,8 @@ module.exports = (db, server, userHandler) => {
                         name: true,
                         user: true,
                         tags: true,
-                        targets: true
+                        targets: true,
+                        forwardedDisabled: true
                     }
                 },
                 paginatedField: 'addrview',
@@ -234,7 +236,8 @@ module.exports = (db, server, userHandler) => {
                     name: addressData.name || false,
                     address: addressData.address,
                     user: addressData.user,
-                    forwarded: addressData.targets && true,
+                    forwarded: !!addressData.targets,
+                    forwardedDisabled: !!(addressData.targets && addressData.forwardedDisabled),
                     targets: addressData.targets && addressData.targets.map(t => t.value),
                     tags: addressData.tags || []
                 }))
@@ -1604,6 +1607,7 @@ module.exports = (db, server, userHandler) => {
      * @apiParam {String[]} [targets] An array of forwarding targets. The value could either be an email address or a relay url to next MX server ("smtp://mx2.zone.eu:25") or an URL where mail contents are POSTed to. If set then overwrites previous targets array
      * @apiParam {Number} [forwards] Daily allowed forwarding count for this address
      * @apiParam {String[]} [tags] A list of tags associated with this address
+     * @apiParam {Boolean} [forwardedDisabled] If true then disables forwarded address (stops forwarding messages)
      * @apiParam {Object} [autoreply] Autoreply information
      * @apiParam {Boolean} [autoreply.status] If true, then autoreply is enabled for this address
      * @apiParam {String} [autoreply.start] Either a date string or boolean false to disable start time checks
@@ -1672,6 +1676,7 @@ module.exports = (db, server, userHandler) => {
                         .max(128 * 1024)
                 }),
                 tags: Joi.array().items(Joi.string().trim().max(128)),
+                forwardedDisabled: Joi.boolean().empty('').truthy(['Y', 'true', 'yes', 'on', '1', 1]).falsy(['N', 'false', 'no', 'off', '0', 0, '']),
                 sess: Joi.string().max(255),
                 ip: Joi.string().ip({
                     version: ['ipv4', 'ipv6'],
@@ -1712,6 +1717,10 @@ module.exports = (db, server, userHandler) => {
 
             if (result.value.name) {
                 updates.name = result.value.name;
+            }
+
+            if (result.value.forwardedDisabled !== undefined) {
+                updates.forwardedDisabled = result.value.forwardedDisabled;
             }
 
             if (result.value.autoreply) {
@@ -2045,7 +2054,8 @@ module.exports = (db, server, userHandler) => {
      * @apiSuccess {String} autoreply.text Autoreply plaintext content
      * @apiSuccess {String} autoreply.html Autoreply HTML content
      * @apiSuccess {String} created Datestring of the time the address was created
-     * @apiSuccess {String[]} results.tags List of tags associated with the Address
+     * @apiSuccess {String[]} tags List of tags associated with the Address
+     * @apiSuccess {Boolean} forwardedDisabled If true then the forwarded address is disabled
      *
      * @apiError error Description of the error
      *
@@ -2163,6 +2173,7 @@ module.exports = (db, server, userHandler) => {
                 },
                 autoreply: addressData.autoreply || { status: false },
                 tags: addressData.tags || [],
+                forwardedDisabled: addressData.targets && addressData.forwardedDisabled,
                 created: addressData.created
             });
 


### PR DESCRIPTION
Allow disabling a forwarded address, just like you would disable a user. This results in a `550 Mailbox disabled, not accepting messages`.

I used the variable name forwardedDisabled as I thought it would reduce confusion when listing normal addresses together with forwarded addresses. Let me know if you have other thoughts.

A PR on haraka-plugin-wildduck should be linked below 😁 