### PR TITLE
Fix for issue 232, letsencrypt cert generation fails because of hard-…

### DIFF
--- a/setup/13_install_ssl_certs.sh
+++ b/setup/13_install_ssl_certs.sh
@@ -19,7 +19,7 @@ echo '#!/bin/bash
 echo "OK"' > /usr/local/bin/reload-services.sh
 chmod +x /usr/local/bin/reload-services.sh
 
-/root/.acme.sh/acme.sh --issue --nginx \
+~/.acme.sh/acme.sh --issue --nginx \
     -d "$HOSTNAME" \
     --key-file       /etc/wildduck/certs/privkey.pem  \
     --fullchain-file /etc/wildduck/certs/fullchain.pem \


### PR DESCRIPTION
…coded root path. Use the home directory instead, which is where acme.sh installs.