### PR TITLE
Add argon2i hash support

### DIFF
--- a/lib/hashes.js
+++ b/lib/hashes.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const bcrypt = require('bcryptjs');
+const argon2 = require('argon2');
 const pbkdf2 = require('@phc/pbkdf2'); // see https://www.npmjs.com/package/@phc/pbkdf2
 // this crap is only needed to support legacy users imported from some older system
 const cryptMD5 = require('./md5/cryptmd5').cryptMD5;
@@ -17,6 +18,8 @@ module.exports.hash = async password => {
                 saltSize: consts.PDKDF2_SALT_SIZE,
                 digest: consts.PDKDF2_DIGEST
             });
+        case 'argon2i':
+            return await argon2.hash(password);
         case 'bcrypt':
         default:
             return await bcrypt.hash(password, consts.BCRYPT_ROUNDS);
@@ -32,6 +35,8 @@ module.exports.compare = async (password, hash) => {
     algo = (algo || '').toString().toLowerCase();
 
     switch (algo) {
+        case 'argon2i':
+            return await argon2.verify(hash, password);
         case 'pbkdf2-sha512':
         case 'pbkdf2-sha256':
         case 'pbkdf2-sha1':

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "dependencies": {
         "@phc/pbkdf2": "1.1.14",
         "accesscontrol": "2.2.1",
+        "argon2": "0.26.2",
         "base32.js": "0.1.0",
         "bcryptjs": "2.4.3",
         "gelf": "2.0.1",


### PR DESCRIPTION
NextCloud uses `argon2i` has its hasing mechanism in some circumstances (https://help.nextcloud.com/t/how-the-users-passwords-ar-encrypted-at-database/29292/2 ). To successfully integrate nextcloud with wildduck using provisioning hooks, it's good to be able to pass the argon2i hash to wildduck directly, rather than needing to carry around multiple hashes, or worse, the plaintext password.

This PR adds simple argon2i support to wildduck. It's a strong algorithm so there's no desire to rehash it to bcrypt or so.

I couldn't see that the hashes library has tests at the moment; should I add them as part of this PR? I always feel a little uncomfortable adding code without tests ^^.

Here's the RFC that added argon2i to wildduck, and where I got an example hash from: https://wiki.php.net/rfc/argon2_password_hash

```
$argon2i$v=19$m=65536,t=3,p=1$SWhIcG5MT21Pc01PbWdVZw$WagZELICsz7jlqOR2YzoEVTWb2oOX1tYdnhZYXxptbU
```

NextCloud prepends `2|` to these hashes, which is unfortunate, but that's easy to strip off prior to submitting them to wildduck, so I didn't include any support for that here.

Here's `password` hashed by the `argon2` library we're using:

```
'$argon2i$v=19$m=4096,t=3,p=1$IILP1UFMKYC1wrOAp88njQ$fneTNbiGcvZrIcsyniE0+QXrGFlTzbKGbhQYPLYBR6s'
```

It has support for argon2d and argon2id as well, but those are more used in crypto stuff than passsword hashing.