### PR TITLE
add support for sha512crypt hashes during migration

### DIFF
--- a/lib/hashes.js
+++ b/lib/hashes.js
@@ -2,6 +2,7 @@
 
 const bcrypt = require('bcryptjs');
 const pbkdf2 = require('@phc/pbkdf2'); // see https://www.npmjs.com/package/@phc/pbkdf2
+let unixcrypt = require("unixcrypt")
 // this crap is only needed to support legacy users imported from some older system
 const cryptMD5 = require('./md5/cryptmd5').cryptMD5;
 const consts = require('./consts');
@@ -41,7 +42,8 @@ module.exports.compare = async (password, hash) => {
         case '2b':
         case '2y':
             return await bcrypt.compare(password, hash);
-
+        case '6':
+            return await unixcryptCompareAsync(password, hash);
         case '1': {
             let result;
 
@@ -70,7 +72,9 @@ module.exports.shouldRehash = hash => {
         case '2b':
         case '2y':
             return consts.DEFAULT_HASH_ALGO !== 'bcrypt';
-
+        case '6':
+            //Rehash sha512crypt to default sha256
+            return true;
         case '1': {
             return consts.DEFAULT_HASH_ALGO !== 'md5-crypt';
         }
@@ -79,3 +83,11 @@ module.exports.shouldRehash = hash => {
             return false;
     }
 };
+
+
+async function unixcryptCompareAsync(password, hash) {
+    password = (password || '').toString();
+    hash = (hash || '').toString();
+
+    return unixcrypt.verify(password, hash);
+}

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
         "smtp-server": "3.7.0",
         "speakeasy": "2.0.0",
         "u2f": "0.1.3",
+        "unixcrypt": "^1.0.11",
         "uuid": "8.2.0",
         "wild-config": "1.5.1",
         "yargs": "15.3.1"


### PR DESCRIPTION
This PR allows creating users with hashed passwords with "$6" prefix for the sha512 crypt algorithm. It also marks any such hashes for rehashing back to sha256.