### PR TITLE
Fix custom 2fa api response

### DIFF
--- a/lib/api/2fa/custom.js
+++ b/lib/api/2fa/custom.js
@@ -83,10 +83,10 @@ module.exports = (db, server, userHandler) => {
             }
 
             let user = new ObjectID(result.value.user);
-            let success = await userHandler.enableCustom2fa(user, result.value);
+            let userHandlerResponse = await userHandler.enableCustom2fa(user, result.value);
 
             res.json({
-                success
+                success: userHandlerResponse.success
             });
 
             return next();


### PR DESCRIPTION
Currently /users/:user/2fa/custom responds with the following :
```json
{
    "success": {
        "success": true,
        "disabled2fa": true
    }
}
```

This fixes the response to be in line with the docs and all other api methods.