### PR TITLE
Fix disable custom 2FA response

### DIFF
--- a/lib/api/2fa/custom.js
+++ b/lib/api/2fa/custom.js
@@ -166,19 +166,19 @@ module.exports = (db, server, userHandler) => {
             }
 
             let user = new ObjectID(result.value.user);
-            let { success, disabled2fa } = await userHandler.disableCustom2fa(user, result.value);
+            let disabled2fa = await userHandler.disableCustom2fa(user, result.value);
 
-            if (!success) {
+            if (!disabled2fa) {
                 res.json({
-                    error: 'Failed to enable 2FA',
-                    code: '2FAEnableFailed'
+                    error: 'Failed to disable 2FA',
+                    code: '2FADisableFailed'
                 });
                 return next();
             }
 
             if (disabled2fa && req.accessToken && typeof req.accessToken.update === 'function') {
                 try {
-                    // update access token data for current session after U2F enabled
+                    // update access token data for current session after custom 2FA disabled
                     await req.accessToken.update();
                 } catch (err) {
                     // ignore
@@ -186,7 +186,7 @@ module.exports = (db, server, userHandler) => {
             }
 
             res.json({
-                success
+                success: true
             });
 
             return next();


### PR DESCRIPTION
Similar to #262, wildduck would return this when successfully disabling custom 2FA:
```json
{
  "error": "Failed to enable 2FA",
  "code": "2FAEnableFailed"
}
```

This fixes the issue. Side note, have you ever looked into TypeScript? I personally have come to love it, and it would prevent exactly these kinds of issues.