### PR TITLE
Fix api giving ObjectId instead of string

### DIFF
--- a/lib/api/addresses.js
+++ b/lib/api/addresses.js
@@ -247,7 +247,7 @@ module.exports = (db, server, userHandler) => {
                         id: addressData._id.toString(),
                         name: addressData.name || false,
                         address: addressData.address,
-                        user: addressData.user,
+                        user: addressData.user.toString(),
                         forwarded: !!addressData.targets,
                         forwardedDisabled: !!(addressData.targets && addressData.forwardedDisabled),
                         targets: addressData.targets && addressData.targets.map(t => t.value),
@@ -2426,7 +2426,7 @@ module.exports = (db, server, userHandler) => {
                     success: true,
                     id: addressData._id.toString(),
                     address: addressData.address,
-                    user: addressData.user,
+                    user: addressData.user.toString(),
                     tags: addressData.tags || [],
                     created: addressData.created
                 };


### PR DESCRIPTION
Unsure what changed to cause this, but the response of `/addresses/resolve/:address` responded with an ObjectId instead of a string for `user` like this:
```json
{
    "success": true,
    "id": "5e7574f5a2bd6304e096a8c2",
    "address": "john@example.com",
    "user": {
        "_bsontype": "ObjectID",
        "id": {
            "type": "Buffer",
            "data": [
                94,
                117,
                116,
                245,
                162,
                189,
                99,
                4,
                224,
                150,
                168,
                188
            ]
        }
    },
    "tags": [],
    "created": "2020-03-21T01:59:17.443Z"
}
```

This fixes it. 😁 