### PR TITLE
Moved "greylist" and "soft reject" to same case block.

### DIFF
--- a/lib/filter-handler.js
+++ b/lib/filter-handler.js
@@ -304,10 +304,10 @@ class FilterHandler {
 
                     case 'rewrite subject':
                     case 'soft reject':
+                    case 'greylist':
                         spamScore = 50;
                         break;
 
-                    case 'greylist':
                     case 'add header':
                         spamScore = 25;
                         break;


### PR DESCRIPTION
In Rspamd "greylist" and "soft reject" actions are synonymous.
Which one is emitted depends on the greylisting module configuration.