### PR TITLE
Add example values for getUserAddressregister

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -281,17 +281,20 @@ paths:
                   required: true
                   schema:
                       type: string
+                      example: 507f1f77bcf86cd799439011
                 - name: query
                   in: query
                   description: Prefix of an address or a name
                   required: true
                   schema:
                       type: string
+                      example: john
                 - name: limit
                   in: query
                   description: How many records to return
                   schema:
                       type: number
+                      example: 25
             responses:
                 '200':
                     description: Success
@@ -5407,12 +5410,15 @@ components:
                 id:
                     type: string
                     description: ID of the Address
+                    example: 507f1f77bcf86cd799439011
                 name:
                     type: string
                     description: Name from address header
+                    example: John Doe
                 address:
                     type: string
                     description: E-mail address string
+                    example: john@example.com
         GetASPsResult:
             required:
                 - id


### PR DESCRIPTION
Ideally should be done for all endpoints, but it's easier to start with the newly added ones 😁 

Makes the examples in the doc a lot more rich:
![image](https://user-images.githubusercontent.com/1346804/99558406-faeb0580-29c3-11eb-8799-67b853f694d2.png)

Yes, I'm a bit bored today :)