### PR TITLE
DKIM: changed encoding of public and private keys

### DIFF
--- a/lib/dkim-handler.js
+++ b/lib/dkim-handler.js
@@ -30,11 +30,11 @@ class DkimHandler {
             modulusLength: keyBits || 2048, // options
             publicExponent: keyExponent || 65537,
             publicKeyEncoding: {
-                type: 'pkcs1',
+                type: 'spki',
                 format: 'pem'
             },
             privateKeyEncoding: {
-                type: 'pkcs1',
+                type: 'pkcs8',
                 format: 'pem'
             }
         });


### PR DESCRIPTION
I am having a hard time making DKIM generated by the API to work in gmail.

<img width="1000" alt="Screen Shot 2021-08-30 at 1 31 06 PM" src="https://user-images.githubusercontent.com/8105211/131290006-290ca3f5-d947-41eb-b348-eddcd70b2643.png">

I found this site to verify DKIM public key: https://dkimcore.org/c/keycheck

All keys being generated by the API appears to be invalid based on the site above.

<img width="1081" alt="Screen Shot 2021-08-30 at 1 34 33 PM" src="https://user-images.githubusercontent.com/8105211/131290097-8b419619-d937-47c8-a664-ab7d34fb3404.png">

I made changes in the encoding when generating, which is also what is noted in this page: https://stackoverflow.com/questions/51942824/nodejs-generate-valid-pem-keys-for-signing-and-verifying-messages

Now it worked:

<img width="995" alt="Screen Shot 2021-08-30 at 1 30 48 PM" src="https://user-images.githubusercontent.com/8105211/131290028-c31b8d5c-a15f-454d-95fe-44466f80fe4d.png">

<img width="719" alt="Screen Shot 2021-08-30 at 1 33 59 PM" src="https://user-images.githubusercontent.com/8105211/131290061-599da40c-c755-4463-bdad-16cd57e23724.png">
