### PR TITLE
Fixed bug where ssl certs without a secret are not working probably

### DIFF
--- a/lib/encrypt.js
+++ b/lib/encrypt.js
@@ -66,7 +66,7 @@ async function decrypt(encryptedData, secret, defaultCipher) {
         return encryptedData;
     }
 
-    if (!secret) {
+    if (!secret && decryptData.format !== 'cleartext') {
         // data is encrypted but we do not have a secret
         let err = new Error('Failed to decrypt data. No secret provided.');
         err.responseCode = 500;


### PR DESCRIPTION
SSL certificates that are not encrypted with a secret are not working.
Instead, an error occurs because the provided secret is undefined.
This pull request fixes the bug when a "cleartext" SSL certificate is provided.