### PR TITLE
Be resilient to missing acme config

### DIFF
--- a/acme.js
+++ b/acme.js
@@ -54,7 +54,7 @@ server.use(
 );
 
 module.exports = done => {
-    if (!config.acme.agent.enabled) {
+    if (!config.acme || !config.acme.agent || !config.acme.agent.enabled) {
         return setImmediate(() => done(null, false));
     }
 


### PR DESCRIPTION
In the gitter chat someone with an old config format was having issues
because they didn't have an [acme] section in the config file; there isn't
really any reason you should need that if you don't use it, so this fix
just makes it so it will disable acme if the config isn't present as well
as if it is but it's disabled