### PR TITLE
ci: add github actions docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,52 @@
+name: Build and publish a Docker image to Docker hub and ghcr.io
+on:
+    push:
+        branches:
+            - master
+        tags:
+            - 'v*.*.*'
+
+jobs:
+    docker:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+            - name: Docker meta
+              id: meta
+              uses: docker/metadata-action@v3
+              with:
+                  # list of Docker images to use as base name for tags
+                  images: |
+                      nodemailer/wildduck
+                      ghcr.io/nodemailer/wildduck
+                  # generate Docker tags based on the following events/attributes
+                  tags: |
+                      type=semver,pattern={{version}}
+                      type=semver,pattern={{major}}.{{minor}}
+                      type=semver,pattern={{major}}
+                      type=sha
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v1
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v1
+            - name: Login to DockerHub
+              if: github.event_name != 'pull_request'
+              uses: docker/login-action@v1
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+            - name: Login to GHCR
+              if: github.event_name != 'pull_request'
+              uses: docker/login-action@v1
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.repository_owner }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+            - name: Build and push
+              uses: docker/build-push-action@v2
+              with:
+                  context: .
+                  push: ${{ github.event_name != 'pull_request' }}
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
As described in [this comment](https://github.com/nodemailer/wildduck/issues/361#issuecomment-985567573), the long term goal was to move the Docker build to GitHub Actions eventually. 

This PR implements building and pushing the image to the Docker Hub and ghcr.io on master pushes, as well as new tags. I'm not sure what your release strategy is, but I'm happy to adjust the action to  accommodate your usual workflow. 

Before merging, you need to create `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets to authenticate the push action. 

Hope we can move this along quickly to have up-to-date images under the official tag again soon. 
