### PR TITLE
Updated wildduck git clone path

### DIFF
--- a/setup/07_install_wildduck.sh
+++ b/setup/07_install_wildduck.sh
@@ -19,7 +19,7 @@ rm -rf /etc/wildduck
 
 # fresh install
 cd /var/opt
-git clone --bare git://github.com/nodemailer/wildduck.git
+git clone --bare https://github.com/nodemailer/wildduck.git
 
 # create update hook so we can later deploy to this location
 hook_script wildduck

--- a/setup/08_install_haraka.sh
+++ b/setup/08_install_haraka.sh
@@ -20,7 +20,7 @@ rm -rf /opt/haraka
 
 # fresh install
 cd /var/opt
-git clone --bare git://github.com/nodemailer/haraka-plugin-wildduck.git
+git clone --bare https://github.com/nodemailer/haraka-plugin-wildduck.git
 echo "#!/bin/bash
 git --git-dir=/var/opt/haraka-plugin-wildduck.git --work-tree=/opt/haraka/plugins/wildduck checkout "\$3" -f
 cd /opt/haraka/plugins/wildduck

--- a/setup/09_install_zone_mta.sh
+++ b/setup/09_install_zone_mta.sh
@@ -21,8 +21,8 @@ rm -rf /etc/zone-mta
 
 # fresh install
 cd /var/opt
-git clone --bare git://github.com/zone-eu/zone-mta-template.git zone-mta.git
-git clone --bare git://github.com/nodemailer/zonemta-wildduck.git
+git clone --bare https://github.com/zone-eu/zone-mta-template.git zone-mta.git
+git clone --bare https://github.com/nodemailer/zonemta-wildduck.git
 
 # create update hooks so we can later deploy to this location
 hook_script zone-mta

--- a/setup/10_install_wildduck_webmail.sh
+++ b/setup/10_install_wildduck_webmail.sh
@@ -18,7 +18,7 @@ rm -rf /opt/wildduck-webmail
 
 # fresh install
 cd /var/opt
-git clone --bare git://github.com/nodemailer/wildduck-webmail.git
+git clone --bare https://github.com/nodemailer/wildduck-webmail.git
 
 # create update hook so we can later deploy to this location
 hook_script_bower wildduck-webmail


### PR DESCRIPTION
Since January 11 of 2022 Github no longer supports the unsecure git:// clone paths. The recommended way is now using https.
More info here: https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git