### PR TITLE
Fixed Webauthn registration failing.

### DIFF
--- a/lib/api/2fa/webauthn.js
+++ b/lib/api/2fa/webauthn.js
@@ -240,7 +240,7 @@ module.exports = (db, server, userHandler) => {
             res.charSet('utf-8');
             const schema = Joi.object().keys({
                 user: Joi.string().hex().lowercase().length(24).required(),
-                origin: Joi.string().empty('').uri().required(),
+                origin: Joi.string().empty('').domain().required(),
                 authenticatorAttachment: Joi.string()
                     .valid('platform', 'cross-platform')
                     .example('cross-platform')

--- a/lib/api/2fa/webauthn.js
+++ b/lib/api/2fa/webauthn.js
@@ -128,7 +128,7 @@ module.exports = (db, server, userHandler) => {
             const schema = Joi.object().keys({
                 user: Joi.string().hex().lowercase().length(24).required(),
                 description: Joi.string().empty('').max(1024).required().description('Descriptive name for the authenticator'),
-                origin: Joi.string().empty('').uri().required(),
+                origin: Joi.string().empty('').domain().required().description('The valid domain name to which the key gets registered to'),
 
                 authenticatorAttachment: Joi.string()
                     .valid('platform', 'cross-platform')

--- a/lib/user-handler.js
+++ b/lib/user-handler.js
@@ -2609,6 +2609,7 @@ class UserHandler {
             Object.assign(
                 {
                     authenticatorAttachment: data.authenticatorAttachment
+                    rpId: data.origin
                 },
                 config.webauthn
             )

--- a/lib/user-handler.js
+++ b/lib/user-handler.js
@@ -2392,6 +2392,7 @@ class UserHandler {
             Object.assign(
                 {
                     authenticatorAttachment: data.authenticatorAttachment
+                    rpId: data.origin
                 },
                 config.webauthn
             )


### PR DESCRIPTION
The webauthn registration logic expects the rpId / rp.id value to be a valid eTLD+1. Because currently the user passed origin doesn't get passed into Fido2Lib the returned challenge object doesn't contain a valid domain to register the credentials for. 

This could be bypassed by removing the rp.id key from the returned object, but the attestation fails later with the error "origin is not a valid eTLD+1". This PR should fix both issues.

Maybe we should also add the abilty to pass in rpName value, in case in the future a single wildduck instance gets used for multiple email clients.

Also maybe should rename origin now that it no longer actually is origin.