### PR TITLE
Added rpId to webauthnAssertAuthentication expectations

### DIFF
--- a/lib/user-handler.js
+++ b/lib/user-handler.js
@@ -2713,7 +2713,8 @@ class UserHandler {
             factor: 'either',
             publicKey: credentialData.publicKey,
             prevCounter: credentialData.counter,
-            userHandle: null
+            userHandle: null,
+            rpId: config.webauthn.rpId
         };
 
         const f2l = new Fido2Lib(Object.assign({}, config.webauthn));


### PR DESCRIPTION
This allows for authentication from subdomains. Fido2Lib.assertionResult compares the rpIdHash returned by the users browser, and since the key is created on the main domain it can't use the passed in origin for the hash comparison. 

The related Fido2Lib line: https://github.com/webauthn-open-source/fido2-lib/blob/a5003fa5bf95a3b154ea340ecc39165a9b04de59/lib/validator.js#L437