### PR TITLE
Webauthn registration now only excludes same type credentials

### DIFF
--- a/lib/user-handler.js
+++ b/lib/user-handler.js
@@ -2410,11 +2410,17 @@ class UserHandler {
         });
 
         if (userData.webauthn && userData.webauthn.credentials && userData.webauthn.credentials.length) {
-            registrationOptions.excludeCredentials = userData.webauthn.credentials.map(credentialData => ({
-                rawId: credentialData.rawId.toString('hex'), // hex value
-                type: credentialData.type,
-                transports: credentialData.authenticatorAttachment === 'platform' ? ['internal'] : ['usb', 'nfc', 'ble']
-            }));
+            registrationOptions.excludeCredentials = userData.webauthn.credentials.reduce((excludedCredentials, credentialData) => {
+                if (credentialData.authenticatorAttachment === data.authenticatorAttachment) {
+                    excludedCredentials.push({
+                        rawId: credentialData.rawId.toString('hex'), // hex value
+                        type: credentialData.type,
+                        transports: credentialData.authenticatorAttachment === 'platform' ? ['internal'] : ['usb', 'nfc', 'ble'],
+                    });
+
+                }
+                return excludedCredentials;
+            }, []);
         }
 
         // store chalenge


### PR DESCRIPTION
This fixes what seems to be a Mac fingerprint reader specific error, where if you have a cross platform authenticator registered, and then try to register a platform authenticator the credentials.create() function always end-s up timing out. 
But returning only the same type of credentials fixes this.