### PR TITLE
Plugin support for submitting emails via API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ config/production.*
 config/development.*
 package-lock.json*
 certs/test-*
+zmta-milter
+zmta-milter.toml

--- a/lib/api/messages.js
+++ b/lib/api/messages.js
@@ -2992,6 +2992,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                 let message = maildrop.push(
                     {
                         user: userData._id,
+                        userEmail: userData.address,
                         reason: 'submit',
                         from: envelope.from,
                         to: envelope.to,

--- a/lib/api/submit.js
+++ b/lib/api/submit.js
@@ -465,6 +465,7 @@ module.exports = (db, server, messageHandler, userHandler, settingsHandler) => {
                                                 let message = maildrop.push(
                                                     {
                                                         user: userData._id,
+                                                        userEmail: userData.address,
                                                         parentId: messageId,
                                                         reason: 'submit',
                                                         from: compiledEnvelope.from,

--- a/lib/forward.js
+++ b/lib/forward.js
@@ -13,8 +13,7 @@ module.exports = (options, callback) => {
 
         targets: options.targets,
 
-        interface: 'forwarder',
-        runPlugins: true
+        interface: 'forwarder'
     };
 
     let message = options.maildrop.push(mail, (err, ...args) => {

--- a/lib/maildropper.js
+++ b/lib/maildropper.js
@@ -97,7 +97,12 @@ class Maildropper {
         };
 
         if (options.user) {
-            envelope.user = options.user.toString();
+            envelope.userId = options.user.toString();
+        }
+
+        if (options.userEmail) {
+            // prefer email address as the username
+            envelope.user = options.userEmail;
         }
 
         if (options.parentId) {


### PR DESCRIPTION
Added support for the ZoneMTA plugins for API submissions. This is needed if you run heuristics about a message being potentially spammy or not and to prevent delivering such emails.