### PR TITLE
Allow wildcard UID range for message updates

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -5702,7 +5702,7 @@ components:
             properties:
                 message:
                     type: string
-                    description: 'Message ID values. Either comma separated numbers (1,2,3) or colon separated range (3:15)'
+                    description: 'Message ID values. Either comma separated numbers (1,2,3) or colon separated range (3:15), or a range from UID to end (3:*)'
                 moveTo:
                     type: string
                     description: ID of the target Mailbox if you want to move messages

--- a/lib/api/messages.js
+++ b/lib/api/messages.js
@@ -99,7 +99,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
             moveTo: Joi.string().hex().lowercase().length(24),
 
             message: Joi.string()
-                .regex(/^\d+(,\d+)*$|^\d+:\d+$/i)
+                .regex(/^\d+(,\d+)*$|^\d+:(\d+|\*)$/i)
                 .required(),
 
             seen: booleanSchema,
@@ -180,18 +180,28 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                     .map(uid => Number(uid))
                     .sort((a, b) => a - b)
             };
-        } else if (/^\d+:\d+$/.test(message)) {
+        } else if (/^\d+:(\d+|\*)$/.test(message)) {
             let parts = message
                 .split(':')
                 .map(uid => Number(uid))
-                .sort((a, b) => a - b);
+                .sort((a, b) => {
+                    if (a === '*') {
+                        return 1;
+                    }
+                    if (b === '*') {
+                        return -1;
+                    }
+                    return a - b;
+                });
             if (parts[0] === parts[1]) {
                 messageQuery = parts[0];
             } else {
                 messageQuery = {
-                    $gte: parts[0],
-                    $lte: parts[1]
+                    $gte: parts[0]
                 };
+                if (!isNaN(parts[1])) {
+                    messageQuery.$lte = parts[1];
+                }
             }
         } else {
             res.status(404);

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
         "mongodb-extended-json": "1.11.1",
         "node-forge": "1.3.1",
         "node-html-parser": "5.3.3",
-        "nodemailer": "6.7.6",
+        "nodemailer": "6.7.7",
         "npmlog": "6.0.2",
         "openpgp": "5.3.1",
         "pem-jwk": "2.0.0",
@@ -94,7 +94,7 @@
         "uuid": "8.3.2",
         "wild-config": "1.6.1",
         "yargs": "17.5.1",
-        "zone-mta": "3.4.0"
+        "zone-mta": "3.4.1"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
When updating messages via API, there's a new message range option `*` that indicates the last message:

```
curl -XPUT ".../messages" \
  -H 'content-type:application/json' \
  -d '{
    "message": "1:*",
    "seen": false
  }'
```