### PR TITLE
Remove credential transport type from authenticationOptions allowed credentials list

### DIFF
--- a/lib/user-handler.js
+++ b/lib/user-handler.js
@@ -2647,7 +2647,6 @@ class UserHandler {
             .map(credentialData => ({
                 rawId: credentialData.rawId.toString('hex'),
                 type: credentialData.type,
-                transports: credentialData.authenticatorAttachment === 'platform' ? ['internal'] : ['usb', 'nfc', 'ble']
             }));
 
         // store chalenge


### PR DESCRIPTION
This is marked as SHOULD in the spec, but it causes chrome 103 to not display "android phone" as a suitable option for authentication even if it is added and the hybrid transportation type is added to the allowed list.