### PR TITLE
Add OpenAPI verification badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   <a href="https://snyk.io/test/github/nodemailer/wildduck" target="_blank"><img src="https://img.shields.io/snyk/vulnerabilities/github/nodemailer/wildduck" alt="Vulnerabilities" /></a>
   <a href="https://hub.docker.com/r/nodemailer/wildduck" target="_blank"><img src="https://img.shields.io/docker/image-size/nodemailer/wildduck?label=docker%20image" alt="docker" /></a>
   <a href="https://gitter.im/nodemailer/wildduck" target="_blank"><img src="https://img.shields.io/gitter/room/nodemailer/wildduck?color=orange" alt="gitter" /></a>
+  <a href="https://docs.wildduck.email/api/openapi.yml"><img src="https://img.shields.io/swagger/valid/3.0?specUrl=https%3A%2F%2Fdocs.wildduck.email%2Fapi%2Fopenapi.yml"></a>
 </p>
 
 WildDuck uses a distributed database (sharded + replicated MongoDB) as a backend for storing all data, including emails.


### PR DESCRIPTION
Having the OpenAPI verification badge on the README is not only a sign of quality of a great feature but also a good indicator to quickly catch errors in the OpenAPI file.