### PR TITLE
Fix 05_install_packages.sh for python3

### DIFF
--- a/setup/05_install_packages.sh
+++ b/setup/05_install_packages.sh
@@ -6,7 +6,7 @@ echo -e "\n-- Executing ${ORANGE}${OURNAME}${NC} subscript --"
 
 # install nginx
 apt-get update
-apt-get -q -y install pwgen git ufw build-essential libssl-dev dnsutils python software-properties-common nginx wget mongodb-org nodejs redis-server clamav clamav-daemon
+apt-get -q -y install pwgen git ufw build-essential libssl-dev dnsutils python3 software-properties-common nginx wget mongodb-org nodejs redis-server clamav clamav-daemon
 
 # rspamd
 apt-get -q -y --no-install-recommends install rspamd


### PR DESCRIPTION
This should fix the script installing python as python isnt a valid package on ubuntu 22.04 and im pretty sure its not valid on 20.04 now.