### PR TITLE
Use charset converter from libmime

### DIFF
--- a/imap-core/lib/indexer/indexer.js
+++ b/imap-core/lib/indexer/indexer.js
@@ -9,7 +9,6 @@ const libmime = require('libmime');
 const libcharset = require('libmime/lib/charset');
 const libqp = require('libqp');
 const libbase64 = require('libbase64');
-const iconv = require('iconv-lite');
 const he = require('he');
 const { htmlToText } = require('html-to-text');
 const crypto = require('crypto');

--- a/imap-core/lib/indexer/indexer.js
+++ b/imap-core/lib/indexer/indexer.js
@@ -6,6 +6,7 @@ const BodyStructure = require('./body-structure');
 const createEnvelope = require('./create-envelope');
 const parseMimeTree = require('./parse-mime-tree');
 const libmime = require('libmime');
+const libcharset = require('libmime/lib/charset');
 const libqp = require('libqp');
 const libbase64 = require('libbase64');
 const iconv = require('iconv-lite');
@@ -484,11 +485,7 @@ class Indexer {
                                 .toLowerCase()
                         )
                     ) {
-                        try {
-                            content = iconv.decode(content, charset);
-                        } catch (E) {
-                            // do not decode charset
-                        }
+                        content = libcharset.decode(content, charset);
                     }
 
                     if (flowed) {


### PR DESCRIPTION
The charset decoder in _libmime_ is able to use the missing Japanese encodings.