### PR TITLE
Issue 436: POP3 AUTH PLAIN not working for certain username and password lengths

### DIFF
--- a/lib/pop3/connection.js
+++ b/lib/pop3/connection.js
@@ -881,7 +881,7 @@ class POP3Connection extends EventEmitter {
     }
 
     authPlain(plain, next) {
-        if (!/^[a-zA-Z0-9+/]+=+?$/.test(plain)) {
+        if (!/^(?:[a-zA-Z0-9+/]{4})*(?:(?:[a-zA-Z0-9+/]{3}=)|(?:[a-zA-Z0-9+/]{2}==))?$/.test(plain)) {
             this.send('-ERR malformed command');
             return next();
         }


### PR DESCRIPTION
Replacing the regular expression should fix the issue with POP3 logins with certain password lengths