### PR TITLE
Add threadId to exists event

### DIFF
--- a/lib/handlers/on-copy.js
+++ b/lib/handlers/on-copy.js
@@ -242,7 +242,8 @@ async function copyHandler(server, messageHandler, connection, mailbox, update, 
                 uid: messageData.uid,
                 message: messageData._id,
                 unseen: messageData.unseen,
-                idate: messageData.idate
+                idate: messageData.idate,
+                thread: messageData.thread
             };
             if (junk) {
                 entry.junk = junk;

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -555,7 +555,8 @@ class MessageHandler {
                                                         message: messageData._id,
                                                         modseq: messageData.modseq,
                                                         unseen: messageData.unseen,
-                                                        idate: messageData.idate
+                                                        idate: messageData.idate,
+                                                        thread: messageData.thread,
                                                     },
                                                     () => {
                                                         this.notifier.fire(mailboxData.user);
@@ -1099,7 +1100,8 @@ class MessageHandler {
                                                         uid: uidNext,
                                                         message: insertId,
                                                         unseen: message.unseen,
-                                                        idate: message.idate
+                                                        idate: message.idate,
+                                                        thread: message.thread
                                                     };
                                                     if (junk) {
                                                         entry.junk = junk;
@@ -1237,7 +1239,8 @@ class MessageHandler {
                             uid: uidNext,
                             message: insertId,
                             unseen: messageData.unseen,
-                            idate: messageData.idate
+                            idate: messageData.idate,
+                            thread: messageData.thread
                         };
                         if (junk) {
                             entry.junk = junk;


### PR DESCRIPTION
Similar to #347. Sometimes a message is added to a folder that's not loaded, but since it belongs to a thread of a message that is loaded, we still want to fetch it.