### PR TITLE
Set restify mapFiles to  true

### DIFF
--- a/api.js
+++ b/api.js
@@ -199,7 +199,7 @@ server.use(
     restify.plugins.bodyParser({
         maxBodySize: 0,
         mapParams: true,
-        mapFiles: false,
+        mapFiles: true,
         overrideParams: false
     })
 );


### PR DESCRIPTION
When mapFiles is false then a typical Webkit multipart content disposition with filename passed inside the individual boundaries fails and Joi returns and error about content not existing. Setting mapFiles doesn't cause wildduck to use the filename param from the boundary but, it does allow it work.

If there isn't something I am missing about the desired behavior and this is an acceptable PR, I will submit another with the that functionality. 

```
POST http://localhost:8080/users/{{user}}/storage?accessToken=somesecretvalue
Content-Type: multipart/form-data;boundary="BOUNDARY" 

--BOUNDARY
Content-Disposition: form-data; name="content"; filename="de4dcdf2fadf47c1bddcd1e9230a6821.png"
Content-Type: image/png

< ./1.png
--BOUNDARY
```
### This isn't a issue with the way Restify parses out the name element because this works.
```
POST http://localhost:8080/users/{{user}}/storage?accessToken=somesecretvalue
Content-Type: multipart/form-data;boundary="BOUNDARY" 

--BOUNDARY
Content-Disposition: form-data; name="content"; theExtraFieldIsNotTheProblem="de4dcdf2fadf47c1bddcd1e9230a6821.png"
Content-Type: image/png

< ./1.png
--BOUNDARY
```

### This also works and sets the filename when mapFiles is true
```
POST http://localhost:8080/users/{{user}}/storage?accessToken=somesecretvalue
Content-Type: multipart/form-data;boundary="BOUNDARY" 

--BOUNDARY
Content-Disposition: form-data; name="content"; filename="de4dcdf2fadf47c1bddcd1e9230a6821.png"
Content-Type: image/png

< ./1.png
--BOUNDARY
Content-Disposition: form-data; name="filename"

TheFilename
--BOUNDARY

```