### PR TITLE
Grunt mocha test fixes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,12 +10,19 @@ module.exports = function (grunt) {
         },
 
         mochaTest: {
-            all: {
+            imap: {
                 options: {
                     reporter: 'spec'
                 },
-                // run imap-core tests first
-                src: ['imap-core/test/**/*-test.js', 'test/**/*-test.js']
+                // imap-core tests first
+                src: ['imap-core/test/**/*-test.js']
+            },
+            api: {
+                options: {
+                    reporter: 'spec'
+                },
+                // api tests
+                src: ['test/**/*-test.js']
             }
         },
 

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,2 @@
+test file new for git
+

--- a/test.txt
+++ b/test.txt
@@ -1,2 +1,0 @@
-test file new for git
-


### PR DESCRIPTION
Instead of having just one subtask (subobject) on the mochaTest command that does just one test run - separate the imap-core and api test runs into separate subtasks. That means both test runs will be separate from each other