### PR TITLE
Heap snapshot

### DIFF
--- a/server.js
+++ b/server.js
@@ -160,7 +160,7 @@ process.on('SIGPIPE', () => {
     if (stream) {
         const path = Path.join(
             os.tmpdir(),
-            `Heap-${new Date()
+            `Heap-${process.pid}-${new Date()
                 .toISOString()
                 .substring(0, 19)
                 .replace(/[^0-9T]+/g, '')}.heapsnapshot`


### PR DESCRIPTION
Generate a heap snapshot to tmp folder if SIGPIPE is sent to a process.

```
$ kill -s SIGPIPE 65699
```

```
...
info App All servers started, ready to process some mail
...
info Process PID=66621 Generating heap snapshot...
info Process PID=66621 Generated heap snapshot: /tmp/Heap-66621-20230928T073933.heapsnapshot
```

<img width="902" alt="Screenshot 2023-09-28 at 10 42 59" src="https://github.com/nodemailer/wildduck/assets/132242/6c4528cf-30a5-43db-beef-e8e8eb200a0c">

<img width="901" alt="Screenshot 2023-09-28 at 10 43 33" src="https://github.com/nodemailer/wildduck/assets/132242/7f343981-0b09-41b5-932a-c3524fff37d3">
