### PR TITLE
fix(mailbox-create): Use correct database for loading User data when creating mailboxes

### DIFF
--- a/lib/mailbox-handler.js
+++ b/lib/mailbox-handler.js
@@ -31,7 +31,7 @@ class MailboxHandler {
     }
 
     async createAsync(user, path, opts) {
-        const userData = await this.database.collection('users').findOne({ _id: user }, { projection: { retention: true } });
+        const userData = await this.users.collection('users').findOne({ _id: user }, { projection: { retention: true } });
 
         if (!userData) {
             const err = new Error('This user does not exist');


### PR DESCRIPTION
Use `db.users` not `db.database` when using the `users` collection