### PR TITLE
ZMS-99

### DIFF
--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -538,7 +538,7 @@ class MessageHandler {
                                                     for (let key of keyList) {
                                                         if (parsed[key] && parsed[key].length) {
                                                             for (let addr of parsed[key]) {
-                                                                if (addr.address.includes('noreply') || addr.address.includes('no-reply')) {
+                                                                if (/no-?reply/i.test(addr.address)) {
                                                                     continue;
                                                                 }
                                                                 if (!addresses.some(a => a.address === addr.address)) {

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -19,6 +19,7 @@ const { SettingsHandler } = require('./settings-handler');
 
 // index only the following headers for SEARCH
 const INDEXED_HEADERS = ['to', 'cc', 'subject', 'from', 'sender', 'reply-to', 'message-id', 'thread-index', 'list-id', 'delivered-to'];
+const DISALLOWED_HEADERS_FOR_ADDRESS_REGISTER = ['list-id', 'auto-submitted', 'x-auto-response-suppress'];
 
 openpgp.config.commentstring = 'Plaintext message encrypted by WildDuck Mail Server';
 openpgp.config.versionString = `WildDuck v${packageData.version}`;
@@ -525,6 +526,15 @@ class MessageHandler {
 
                                                 if (parsed) {
                                                     let keyList = mailboxData.specialUse === '\\Sent' ? ['to', 'cc', 'bcc'] : ['from'];
+
+                                                    for (const disallowedHeader of DISALLOWED_HEADERS_FOR_ADDRESS_REGISTER) {
+                                                        // if email contains headers that we do not want,
+                                                        // don't add any emails to address register
+                                                        if (parsed[disallowedHeader]) {
+                                                            return next();
+                                                        }
+                                                    }
+
                                                     for (let key of keyList) {
                                                         if (parsed[key] && parsed[key].length) {
                                                             for (let addr of parsed[key]) {

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -528,6 +528,9 @@ class MessageHandler {
                                                     for (let key of keyList) {
                                                         if (parsed[key] && parsed[key].length) {
                                                             for (let addr of parsed[key]) {
+                                                                if (addr.address.includes('noreply') || addr.address.includes('no-reply')) {
+                                                                    continue;
+                                                                }
                                                                 if (!addresses.some(a => a.address === addr.address)) {
                                                                     addresses.push(addr);
                                                                 }


### PR DESCRIPTION
1. Do not add noreply@ and no-reply@ emails to the address register
2. emails containing list-id, auto-submitted, x-auto-response-suppress headers (one of the provided) are skipped for the address register additions completely.