### PR TITLE
fix: fixed string conversion to utf8 vs binary (closes #563)

### DIFF
--- a/imap-core/lib/imap-composer.js
+++ b/imap-core/lib/imap-composer.js
@@ -60,8 +60,17 @@ class IMAPComposer extends Transform {
             );
         }
 
-        this.push(compiled);
-        this.push('\r\n');
+        // <https://github.com/nodemailer/wildduck/issues/563>
+        // <https://github.com/nodemailer/wildduck/pull/564
+        if (typeof compiled === 'object') {
+          this.push(compiled);
+          this.push('\r\n');
+        } else if (typeof compiled === 'string') {
+          this.push(Buffer.from(compiled + '\r\n', 'binary'));
+        } else {
+          return done(new TypeError('"compiled" was not an object or string'));
+        }
+
         done();
     }
 

--- a/imap-core/lib/imap-composer.js
+++ b/imap-core/lib/imap-composer.js
@@ -60,7 +60,8 @@ class IMAPComposer extends Transform {
             );
         }
 
-        this.push(Buffer.from(compiled + '\r\n', 'binary'));
+        this.push(compiled);
+        this.push('\r\n');
         done();
     }
 


### PR DESCRIPTION
@andris9 this is a core bug that needs merged/fixed

details are in #563 

calling `compiled + "something"` will result in the buffer being converted to utf8 instead of binary, since the default buffer.toString is utf8