### PR TITLE
fix: append causing drafts/other mail to not render in mail clients (closes #566, closes #537)

### DIFF
--- a/imap-core/lib/commands/append.js
+++ b/imap-core/lib/commands/append.js
@@ -5,11 +5,6 @@ const imapTools = require('../imap-tools');
 module.exports = {
     state: ['Authenticated', 'Selected'],
 
-    // we do not show * EXIST response for added message, so keep other notifications quet as well
-    // otherwise we might end up in situation where APPEND emits an unrelated * EXISTS response
-    // which does not yet take into account the appended message
-    disableNotifications: true,
-
     schema: [
         {
             name: 'path',


### PR DESCRIPTION
This fixes #566 and #537.