### PR TITLE
fix: FETCH should not compare by length, but by keys

### DIFF
--- a/lib/handlers/on-fetch.js
+++ b/lib/handlers/on-fetch.js
@@ -142,7 +142,8 @@ module.exports = (server, messageHandler, userCache) => (mailbox, options, sessi
 
                         let pageQuery = Object.assign({}, query);
 
-                        if (options.messages.length !== session.selected.uidList.length) {
+                        // we cannot simply compare length in case messages moved or appended
+                        if (options.messages.sort().join(',') !== session.selected.uidList.sort().join(',')) {
                             // do not use uid selector for 1:*
                             pageQuery.uid = tools.checkRangeQuery(options.messages, false);
                         } else {


### PR DESCRIPTION
This fixes issues such as when message counts in folders were incorrect when messages were moved/appended to them.