### PR TITLE
fix: STORE should not compare by length, but by keys

### DIFF
--- a/lib/handlers/on-store.js
+++ b/lib/handlers/on-store.js
@@ -69,7 +69,8 @@ module.exports = server => (mailbox, update, session, callback) => {
             };
 
             let queryAll = false;
-            if (update.messages.length !== session.selected.uidList.length) {
+            // we cannot simply compare length in case messages moved or appended
+            if (update.messages.sort().join(',') !== session.selected.uidList.sort().join(',')) {
                 // do not use uid selector for 1:*
                 query.uid = tools.checkRangeQuery(update.messages);
             } else {


### PR DESCRIPTION
This fixes issues such as when message counts in folders were incorrect when messages were moved/appended to them.