### PR TITLE
fix: SEARCH should not compare by length, but by keys

### DIFF
--- a/lib/handlers/on-search.js
+++ b/lib/handlers/on-search.js
@@ -102,7 +102,8 @@ module.exports = server => (mailbox, options, session, callback) => {
                                         highestModseq: 0
                                     });
                                 }
-                                if (term.value.length !== session.selected.uidList.length) {
+                                // // we cannot simply compare length in case messages moved or appended
+                                if (term.value.sort().join(',') !== session.selected.uidList.sort().join(',')) {
                                     // not 1:*
                                     parent.push({
                                         uid: tools.checkRangeQuery(term.value, ne)


### PR DESCRIPTION
This fixes issues such as when message counts in folders were incorrect when messages were moved/appended to them.