### PR TITLE
ZMS-109

### DIFF
--- a/lib/imap-notifier.js
+++ b/lib/imap-notifier.js
@@ -78,17 +78,42 @@ class ImapNotifier extends EventEmitter {
         this.subscriber.on('message', (channel, message) => {
             if (channel === 'wd_events') {
                 let data;
-                try {
-                    data = JSON.parse(message);
-                } catch (E) {
-                    return;
+                // if e present at beginning, check if p also is present
+                // if no p -> no json parse
+                // if p -> json parse ONLY p
+                // if e not in beginning but p is -> json parse whole
+
+                if (message[2] === 'e') {
+                    for (let i = 6; i < 6 + 24; i++) {
+                        if (!/[0-9ABCDEF]/i.test(message[i])) {
+                            // check for hex char
+                            return; // incorrect e, e HAS to be hex
+                        }
+                    }
+
+                    data = { e: message.slice(6, 6 + 24) };
+
+                    if (message[33] === 'p') {
+                        // parse next JSON only if the payload is actually there
+                        data.p = JSON.parse('{' + message.slice(32, message.length - 1) + '}').p;
+                    }
+                } else {
+                    try {
+                        data = JSON.parse(message);
+                    } catch (E) {
+                        return;
+                    }
                 }
-                if (data.e && !data.p) {
-                    // events without payload are scheduled, these are notifications about changes in journal
-                    scheduleDataEvent(data.e);
-                } else if (data.e) {
-                    // events with payload are triggered immediatelly, these are actions for doing something
-                    this._listeners.emit(data.e, data.p);
+
+                if (this._listeners._events[data.e] && this._listeners._events[data.e].length > 0) {
+                    // do not schedule or fire/emit empty events
+                    if (data.e && !data.p) {
+                        // events without payload are scheduled, these are notifications about changes in journal
+                        scheduleDataEvent(data.e);
+                    } else if (data.e) {
+                        // events with payload are triggered immediatelly, these are actions for doing something
+                        this._listeners.emit(data.e, data.p);
+                    }
                 }
             }
         });


### PR DESCRIPTION
Wildduck has, if there are many clients connected, high idle CPU usage caused by high amount of JSON parsing that is not usually needed (data can be obtained directly without JSON.parse()).

Removed unnecessary parsing by doing constant time checks, if parsing is needed it is limited to a subset of the data as so make it a little more faster.
Also empty events will not be scheduled or emitted to reduce redundant calls.