### PR TITLE
ZMS-113

### DIFF
--- a/lib/api/messages.js
+++ b/lib/api/messages.js
@@ -1905,7 +1905,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
 
                     from: AddressOptionalName.description('Addres for the From: header'),
 
-                    replyTo: Address.description('Address for the Reply-To: header'),
+                    replyTo: AddressOptionalName.description('Address for the Reply-To: header'),
 
                     to: AddressOptionalNameArray.description('Addresses for the To: header'),
 

--- a/lib/api/messages.js
+++ b/lib/api/messages.js
@@ -25,7 +25,15 @@ const { getMongoDBQuery /*, getElasticSearchQuery*/ } = require('../search-query
 //const { getClient } = require('../elasticsearch');
 
 const BimiHandler = require('../bimi-handler');
-const { Address, AddressOptionalNameArray, Header, Attachment, ReferenceWithAttachments, Bimi } = require('../schemas/request/messages-schemas');
+const {
+    Address,
+    AddressOptionalNameArray,
+    Header,
+    Attachment,
+    ReferenceWithAttachments,
+    Bimi,
+    AddressOptionalName
+} = require('../schemas/request/messages-schemas');
 const { userId, mailboxId, messageId } = require('../schemas/request/general-schemas');
 const { MsgEnvelope } = require('../schemas/response/messages-schemas');
 const { successRes } = require('../schemas/response/general-schemas');
@@ -1895,7 +1903,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                             'base64 encoded message source. Alternatively, you can provide this value as POST body by using message/rfc822 MIME type. If raw message is provided then it overrides any other mail configuration'
                         ),
 
-                    from: Address.description('Addres for the From: header'),
+                    from: AddressOptionalName.description('Addres for the From: header'),
 
                     replyTo: Address.description('Address for the Reply-To: header'),
 

--- a/lib/schemas/request/messages-schemas.js
+++ b/lib/schemas/request/messages-schemas.js
@@ -61,6 +61,7 @@ const Bimi = Joi.object({
 module.exports = {
     Address,
     AddressOptionalNameArray,
+    AddressOptionalName,
     Header,
     Attachment,
     ReferenceWithAttachments,


### PR DESCRIPTION
Allow empty name field in the from header of Upload Message endpoint

EDIT1: Allow empty name field in the reply-to header of Upload message endpoint too.