### PR TITLE
ZMS-116

### DIFF
--- a/lib/schemas/request/messages-schemas.js
+++ b/lib/schemas/request/messages-schemas.js
@@ -47,7 +47,6 @@ const ReferenceWithAttachments = Joi.object({
                     .uppercase()
             )
         )
-        .required()
         .description(
             "If true, then includes all attachments from the original message. If it is an array of attachment ID's includes attachments from the list"
         )


### PR DESCRIPTION
Old documentation contained wrong .required() logic which got incorrectly transferred into the messages.js code (only this file particularly).
Fixed
