### PR TITLE
ZMS-117

### DIFF
--- a/lib/api/messages.js
+++ b/lib/api/messages.js
@@ -2128,7 +2128,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
             let data = {
                 from: result.value.from || { name: userData.name, address: userData.address },
                 date,
-                to: result.value.to ? result.value.to.filter(toObj => toObj.to !== '') : undefined,
+                to: result.value.to ? result.value.to.filter(toObj => toObj.address !== '') : undefined,
                 cc: result.value.cc,
                 bcc: result.value.bcc,
                 subject: result.value.subject || referencedMessage.subject,

--- a/lib/api/messages.js
+++ b/lib/api/messages.js
@@ -1882,7 +1882,14 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
 
                     replyTo: AddressOptionalName.description('Address for the Reply-To: header'),
 
-                    to: AddressOptionalNameArray.description('Addresses for the To: header'),
+                    to: Joi.array()
+                        .items(
+                            Joi.object({
+                                name: Joi.string().empty('').max(255).description('Name of the sender'),
+                                address: Joi.string().email({ tlds: false }).failover('').required().description('Address of the sender')
+                            }).$_setFlag('objectName', 'AddressOptionalName')
+                        )
+                        .description('Addresses for the To: header'),
 
                     cc: AddressOptionalNameArray.description('Addresses for the Cc: header'),
 
@@ -2121,7 +2128,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
             let data = {
                 from: result.value.from || { name: userData.name, address: userData.address },
                 date,
-                to: result.value.to,
+                to: result.value.to ? result.value.to.filter(toObj => toObj.to !== '') : undefined,
                 cc: result.value.cc,
                 bcc: result.value.bcc,
                 subject: result.value.subject || referencedMessage.subject,
@@ -2164,7 +2171,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                 envelope.from = data.from.address = await validateFromAddress(userData, envelopeFrom);
             }
 
-            if (!result.value.to && !envelope.to.length && referencedMessage && ['reply', 'replyAll'].includes(result.value.reference.action)) {
+            if (!data.to && !envelope.to.length && referencedMessage && ['reply', 'replyAll'].includes(result.value.reference.action)) {
                 envelope.to = envelope.to.concat(parseAddresses(referencedMessage.replyTo || [])).concat(parseAddresses(referencedMessage.replyCc || []));
                 data.to = [].concat(referencedMessage.replyTo || []);
                 data.cc = [].concat(referencedMessage.replyCc || []);


### PR DESCRIPTION
Allow to create draft messages with incorrect addresses.
Incorrect addresses are removed, but the message will still be saved, that is if one address is given and it is incorrect the `to` header will be missing, if two addresses are given and one is incorrect the only correct one will be included in the `to` header.