### PR TITLE
fix(message-threading): Take non-standard but conventional subject prefixes into account

### DIFF
--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -1456,12 +1456,13 @@ class MessageHandler {
         options = options || {};
         subject = subject.replace(/\s+/g, ' ').trim();
 
+        // `Re: [EXTERNAL] Re: Fwd: Example subject (fwd)` becomes `Example subject`
         if (options.removePrefix) {
             let match = true;
             while (match) {
                 match = false;
                 subject = subject
-                    .replace(/^(re|fwd?)\s*:|\s*\(fwd\)\s*$/gi, () => {
+                    .replace(/^(re|fwd?)\s*:|^\[.+?\](?=\s.+)|\s*\(fwd\)\s*$/gi, () => {
                         match = true;
                         return '';
                     })


### PR DESCRIPTION
Fixes #603 

Simple change but seems to work well. I suppose this will break up a couple of existing threads when deployed, if those threads have subjects with these kinds of prefixes. Can't really think of a way around that though.

```js
normalizeSubject('[mailop] BIMI boycott?', { removePrefix: true })
"BIMI boycott?"

normalizeSubject('Re: [mailop] BIMI boycott?', { removePrefix: true })
"BIMI boycott?"

normalizeSubject('[mailop] [ADMIN] Re: BIMI boycott?', { removePrefix: true })
"BIMI boycott?"

normalizeSubject('Re: [mailop] [E] Re: BIMI boycott?', { removePrefix: true })
"BIMI boycott?" 

normalizeSubject('Re: [mailop] [E] Re: BIMI boycott? [suffix stays]', { removePrefix: true })
"BIMI boycott? [suffix stays]" 

normalizeSubject('[entirely in brackets stays]', { removePrefix: true })
"[entirely in brackets stays]" 

normalizeSubject('brackets in [the] middle stay', { removePrefix: true })
"brackets in [the] middle stay" 
```