### PR TITLE
ZMS-126

### DIFF
--- a/api.js
+++ b/api.js
@@ -50,8 +50,10 @@ const settingsRoutes = require('./lib/api/settings');
 const healthRoutes = require('./lib/api/health');
 const { SettingsHandler } = require('./lib/settings-handler');
 
-const restifyApiGenerate = require('restifyapigenerate');
+const { RestifyApiGenerate } = require('restifyapigenerate');
+const Joi = require('joi');
 const restifyApiGenerateConfig = require('./config/apigeneration.json');
+const restifyApiGenerate = new RestifyApiGenerate(Joi, __dirname);
 
 let userHandler;
 let mailboxHandler;
@@ -578,7 +580,7 @@ module.exports = done => {
         );
     }
 
-    server.pre(restifyApiGenerate(server, restifyApiGenerateConfig));
+    server.pre(restifyApiGenerate.restifyApiGenerate(server, restifyApiGenerateConfig));
 
     server.on('error', err => {
         if (!started) {

--- a/config/apigeneration.json
+++ b/config/apigeneration.json
@@ -64,5 +64,5 @@
         }
     },
     "security": [{ "AccessTokenAuth": [] }],
-    "docsPath": "/../../openapidocs.json"
+    "docsPath": "/openapidocs.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
                 "restify-cors-middleware2": "2.2.1",
                 "restify-errors": "8.0.2",
                 "restify-logger": "2.0.1",
-                "restifyapigenerate": "1.1.0",
+                "restifyapigenerate": "1.2.0",
                 "search-string": "3.1.0",
                 "seq-index": "1.1.0",
                 "smtp-server": "3.13.2",
@@ -8824,12 +8824,9 @@
             }
         },
         "node_modules/restifyapigenerate": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/restifyapigenerate/-/restifyapigenerate-1.1.0.tgz",
-            "integrity": "sha512-w8grvvJ1GVxGg/cw5yp7kJmJD1C9YHsaBAuxC+J2+qHz+5CPzHDEZU5HKqBx6Dlzln5t2b7/4BvOzCTqrCKTCA==",
-            "dependencies": {
-                "joi": "17.11.0"
-            },
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/restifyapigenerate/-/restifyapigenerate-1.2.0.tgz",
+            "integrity": "sha512-bSw4rQNnu60El+e4Y8oqzvgZgbtc+VemRc7xlCLPm0zE1VSm+6A/QT1Ob+4lu7E17PF+l+OZBIrCEEgxDl3lIg==",
             "engines": {
                 "node": ">=16.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
         "restify-cors-middleware2": "2.2.1",
         "restify-errors": "8.0.2",
         "restify-logger": "2.0.1",
-        "restifyapigenerate": "1.1.0",
+        "restifyapigenerate": "1.2.0",
         "search-string": "3.1.0",
         "seq-index": "1.1.0",
         "smtp-server": "3.13.2",


### PR DESCRIPTION
RestifyApiGenerate now uses the passed Joi package so that version has less impact.
Also __dirname has to be passed in order to maintain correct pathing for the openapidocs.json file