### PR TITLE
Update PBKDF2 iteration count to more closely align with OWASP recommendations

### DIFF
--- a/lib/consts.js
+++ b/lib/consts.js
@@ -43,7 +43,7 @@ module.exports = {
     DEFAULT_HASH_ALGO: 'pbkdf2', //either 'pbkdf2' or 'bcrypt'
 
     BCRYPT_ROUNDS: 11, // bcrypt.js benchmark async in a VPS: 261.192ms, do not want to take it too long
-    PDKDF2_ITERATIONS: 25000,
+    PDKDF2_ITERATIONS: 100000,
     PDKDF2_SALT_SIZE: 16,
     PDKDF2_DIGEST: 'sha256', // 'sha512', 'sha256' or 'sha1'
 


### PR DESCRIPTION
OWASP recommendation for PBKDF2-SHA256 iteration count is 210 000, the current default is 25 000. Which is nearly an order of magnitude smaller.

In order not to make the leap too huge I've increased it to 100 000 (which also aligns with older OWASP recommendations).

https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#pbkdf2