### PR TITLE
fix: fixed edge cases when `session` could be `null`

### DIFF
--- a/lib/pop3/connection.js
+++ b/lib/pop3/connection.js
@@ -1,3 +1,4 @@
+
 'use strict';
 
 const crypto = require('crypto');
@@ -134,7 +135,7 @@ class POP3Connection extends EventEmitter {
                 tnx: 'close',
                 cid: this.id,
                 host: this.remoteAddress,
-                user: this.session.user && this.session.user.username
+                user: this?.session?.user?.username
             },
             'Connection closed to %s',
             this.remoteAddress
@@ -162,7 +163,7 @@ class POP3Connection extends EventEmitter {
             {
                 err,
                 tnx: 'error',
-                user: this.session.user && this.session.user.username
+                user: this?.session?.user?.username
             },
             '%s',
             err.message
@@ -256,7 +257,7 @@ class POP3Connection extends EventEmitter {
                 {
                     tnx: 'receive',
                     cid: this.id,
-                    user: this.session.user && this.session.user.username
+                    user: this?.session?.user?.username
                 },
                 this.id + ' C: <%s bytes of continue data>',
                 Buffer.byteLength(line)
@@ -293,7 +294,7 @@ class POP3Connection extends EventEmitter {
             {
                 tnx: 'receive',
                 cid: this.id,
-                user: this.session.user && this.session.user.username
+                user: this?.session?.user?.username
             },
             this.id + ' C:',
             logLine
@@ -332,10 +333,10 @@ class POP3Connection extends EventEmitter {
         let extensions = [
             'TOP',
             'UIDL',
-            (this.secured || this._server.options.ignoreSTARTTLS) && !this.session.user ? 'USER' : false,
+            (this.secured || this._server.options.ignoreSTARTTLS) && !this?.session?.user ? 'USER' : false,
             'RESP-CODES',
             // https://tools.ietf.org/html/rfc5034#section-6
-            (this.secured || this._server.options.ignoreSTARTTLS) && !this.session.user ? 'SASL PLAIN' : false,
+            (this.secured || this._server.options.ignoreSTARTTLS) && !this?.session?.user ? 'SASL PLAIN' : false,
             // https://tools.ietf.org/html/rfc2449#section-6.6
             'PIPELINING',
             !this.secured && !this._server.options.disableSTARTTLS ? 'STLS' : false,
@@ -374,7 +375,7 @@ class POP3Connection extends EventEmitter {
             return next();
         }
 
-        if (!this.session.user || !args) {
+        if (!this?.session?.user || !args) {
             return next(new Error('malformed command'));
         }
 
@@ -519,8 +520,8 @@ class POP3Connection extends EventEmitter {
                         _message_id: message.id,
                         _message_uid: message.uid,
                         _mailbox: message.mailbox,
-                        _username: this.session.user && this.session.user.username,
-                        _user: this.session.user && this.session.user.id,
+                        _username: this?.session?.user?.username
+                        _user: this?.session?.user?.id,
                         _sess: this.id,
                         _ip: this.remoteAddress
                     });
@@ -734,8 +735,8 @@ class POP3Connection extends EventEmitter {
                     _message_uid: message.uid,
                     _mailbox: message.mailbox,
                     _message_size: message.size,
-                    _username: this.session.user && this.session.user.username,
-                    _user: this.session.user && this.session.user.id,
+                    _username: this?.session?.user?.username,
+                    _user: this?.session?.user?.id,
                     _sess: this.id,
                     _ip: this.remoteAddress,
 
@@ -765,8 +766,8 @@ class POP3Connection extends EventEmitter {
                     _message_uid: message.uid,
                     _mailbox: message.mailbox,
                     _message_size: message.size,
-                    _username: this.session.user && this.session.user.username,
-                    _user: this.session.user && this.session.user.id,
+                    _username: this?.session?.user?.username,
+                    _user: this?.session?.user?.id,
                     _sess: this.id,
                     _ip: this.remoteAddress
                 });
@@ -817,8 +818,8 @@ class POP3Connection extends EventEmitter {
                     _message_uid: message.uid,
                     _mailbox: message.mailbox,
                     _message_size: message.size,
-                    _username: this.session.user && this.session.user.username,
-                    _user: this.session.user && this.session.user.id,
+                    _username: this?.session?.user?.username,
+                    _user: this?.session?.user?.id,
                     _sess: this.id,
                     _ip: this.remoteAddress,
 
@@ -1007,10 +1008,10 @@ class POP3Connection extends EventEmitter {
                         err,
                         tnx: 'listerr',
                         cid: this.id,
-                        user: this.session.user && this.session.user.username
+                        user: this?.session?.user?.username
                     },
                     'Failed listing messages for %s. %s',
-                    this.session.user.username,
+                    this?.session?.user?.username,
                     err.message
                 );
                 return next(err);
@@ -1041,7 +1042,7 @@ class POP3Connection extends EventEmitter {
                 {
                     tnx: 'starttls',
                     cid: this.id,
-                    user: this.session && this.session.user && this.session.user.username,
+                    user: this?.session?.user?.username,
                     cipher: cipher && cipher.name
                 },
                 '[%s] Connection upgraded to TLS using ',

--- a/lib/pop3/connection.js
+++ b/lib/pop3/connection.js
@@ -520,7 +520,7 @@ class POP3Connection extends EventEmitter {
                         _message_id: message.id,
                         _message_uid: message.uid,
                         _mailbox: message.mailbox,
-                        _username: this?.session?.user?.username
+                        _username: this?.session?.user?.username,
                         _user: this?.session?.user?.id,
                         _sess: this.id,
                         _ip: this.remoteAddress


### PR DESCRIPTION
If the session is set to `null` and an `err` occurs, for example here:

<https://github.com/titanism/wildduck/blob/c9188b3766b547b091d140a33308b5c3ec3aa1d4/lib/pop3/connection.js#L1010>

Then an uncaught exception will be thrown.