### PR TITLE
fix: fixed callback invocations to check if session already closed

### DIFF
--- a/lib/pop3/connection.js
+++ b/lib/pop3/connection.js
@@ -727,6 +727,11 @@ class POP3Connection extends EventEmitter {
         }
 
         this._server.onFetchMessage(message, this.session, (err, stream) => {
+            if (!this.session) {
+                // already closed, do nothing
+                return;
+            }
+            
             if (err) {
                 this._server.loggelf({
                     short_message: '[POP3RETR] error',
@@ -810,6 +815,11 @@ class POP3Connection extends EventEmitter {
         }
 
         this._server.onFetchMessage(message, this.session, (err, stream) => {
+            if (!this.session) {
+                // already closed, do nothing
+                return;
+            }
+            
             if (err) {
                 this._server.loggelf({
                     short_message: '[POP3TOP] error',
@@ -1002,6 +1012,11 @@ class POP3Connection extends EventEmitter {
 
     openMailbox(next) {
         this._server.onListMessages(this.session, (err, listing) => {
+            if (!this.session) {
+                // already closed, do nothing
+                return;
+            }
+            
             if (err) {
                 this.logger.info(
                     {


### PR DESCRIPTION
@andris9 in the cases of `onFetchMessage` which returns a `stream` as second argument, should we instead do `stream.destroy()` or something similar inside those conditionals I added?