### PR TITLE
fix: fixed edge case where `session` not set and uncaught exception occurs

### DIFF
--- a/lib/pop3/connection.js
+++ b/lib/pop3/connection.js
@@ -998,6 +998,12 @@ class POP3Connection extends EventEmitter {
                     username,
                     'PLAIN'
                 );
+
+                if (!this.session) {
+                    // already closed, do nothing
+                    return;
+                }
+                    
                 this.session.user = response.user;
 
                 this.openMailbox(err => {


### PR DESCRIPTION
@andris9 can you please merge and release this to npm?

otherwise without this fix, the following uncaught exception occurs:

```sh
TypeError: Cannot set properties of null (setting 'user')\n    at /var/www/production/source/node_modules/.pnpm/wildduck@1.45.3/node_modules/wildduck/lib/pop3/connection.js:1001:35\n    at POP3.onAuth (/var/www/production/source/helpers/on-auth.js:666:5)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)"
```