### PR TITLE
Added thread data to EXPUNGE command

### DIFF
--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -877,7 +877,8 @@ class MessageHandler {
                         ignore: options.session && options.session.id,
                         uid: messageData.uid,
                         message: messageData._id,
-                        unseen: messageData.unseen
+                        unseen: messageData.unseen,
+                        thread: messageData.thread
                     },
                     err => {
                         if (err) {


### PR DESCRIPTION
Added the deleted message thread identifier to the "EXPUNGE" message. 

This has two uses:

1. Unifies the data returned by the updates stream, since the "EXISTS" message already has the thread information in it.
2. Allows for better control over the data being deleted. E.g cache invalidation on front-end for a specific thread only. Instead of having to look through all cached data to find the correct thread to invalidate.