### PR TITLE
Added thread data to FETCH command

### DIFF
--- a/lib/api/messages.js
+++ b/lib/api/messages.js
@@ -3082,6 +3082,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                                     uid: messageData.uid,
                                     flags: messageData.flags,
                                     message: messageData._id,
+                                    thread: messageData.thread,
                                     unseenChange: false
                                 }
                             ];

--- a/lib/api/submit.js
+++ b/lib/api/submit.js
@@ -156,6 +156,7 @@ module.exports = (db, server, messageHandler, userHandler, settingsHandler) => {
                                                 uid: messageData.uid,
                                                 flags: messageData.flags,
                                                 message: messageData._id,
+                                                thread: messageData.thread,
                                                 unseenChange: false
                                             }
                                         ];

--- a/lib/handlers/on-fetch.js
+++ b/lib/handlers/on-fetch.js
@@ -376,6 +376,7 @@ module.exports = (server, messageHandler, userCache) => (mailbox, options, sessi
                                         ignore: session.id,
                                         uid: messageData.uid,
                                         flags: messageData.flags,
+                                        thread: messageData.thread,
                                         message: messageData._id,
                                         unseenChange: true
                                     });

--- a/lib/handlers/on-store.js
+++ b/lib/handlers/on-store.js
@@ -349,6 +349,7 @@ module.exports = server => (mailbox, update, session, callback) => {
                                 ignore: session.id,
                                 uid: message.uid,
                                 flags: message.flags,
+                                thread: message.thread,
                                 message: message._id,
                                 modseq,
                                 unseenChange

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -1862,6 +1862,7 @@ class MessageHandler {
                                     command: 'FETCH',
                                     uid: messageData.uid,
                                     flags: messageData.flags,
+                                    thread: messageData.thread,
                                     message: messageData._id,
                                     unseenChange: 'seen' in changes
                                 });

--- a/pop3.js
+++ b/pop3.js
@@ -407,6 +407,7 @@ function markAsSeen(session, messages, callback) {
                                 command: 'FETCH',
                                 uid: message.uid,
                                 flags: message.flags.concat('\\Seen'),
+                                thread: message.thread,
                                 message: new ObjectId(message.id),
                                 modseq: mailboxData.modifyIndex,
                                 // Indicate that unseen values are changed. Not sure how much though


### PR DESCRIPTION
Added the message thread identifier to the "FETCH" message.

This has two uses:

- Unifies the data returned by the updates stream, since the "EXISTS/EXPUNGE" messages already has the thread information in it.
- Allows for better control over the data being fetched. E.g cache invalidation on front-end for a specific thread only. Instead of having to look through all cached data to find the correct thread to invalidate.