### PR TITLE
ZMSA-17-2: proposal: move storeNodeBodies and addEntries calls in addAsync out of main flow

### DIFF
--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -344,34 +344,30 @@ class MessageHandler {
             throw err;
         };
 
-        try {
-            this.loggelf({
-                short_message: '[MESSAGE-HANDLER] Started storing Initial Node Bodies',
-                _user: mailboxData.user,
-                _sess: options.session && options.session.id,
-                _mailbox: mailboxData._id,
-                _message_id: prepared?.mimeTree?.parsedHeader?.['message-id']
-            });
+        this.loggelf({
+            short_message: '[MESSAGE-HANDLER] Started storing Initial Node Bodies',
+            _user: mailboxData.user,
+            _sess: options.session && options.session.id,
+            _mailbox: mailboxData._id,
+            _message_id: prepared?.mimeTree?.parsedHeader?.['message-id']
+        });
 
-            await new Promise((resolve, reject) => {
-                this.indexer.storeNodeBodies(maildata, mimeTree, err => {
-                    if (err) {
-                        return reject(err);
-                    }
-                    return resolve();
-                });
-            });
+        this.indexer.storeNodeBodies(maildata, mimeTree, err => {
+            let attachmentIds = Object.keys(mimeTree.attachmentMap || {}).map(key => mimeTree.attachmentMap[key]);
 
-            this.loggelf({
-                short_message: '[MESSAGE-HANDLER] Stored Initial Node Bodies',
-                _user: mailboxData.user,
-                _sess: options.session && options.session.id,
-                _mailbox: mailboxData._id,
-                _message_id: prepared?.mimeTree?.parsedHeader?.['message-id']
-            });
-        } catch (err) {
-            return cleanup(err);
-        }
+            if (err && attachmentIds) {
+                // cleanup
+                this.attachmentStorage.deleteManyAsync(attachmentIds, maildata.magic);
+            }
+        });
+
+        this.loggelf({
+            short_message: '[MESSAGE-HANDLER] Stored Initial Node Bodies',
+            _user: mailboxData.user,
+            _sess: options.session && options.session.id,
+            _mailbox: mailboxData._id,
+            _message_id: prepared?.mimeTree?.parsedHeader?.['message-id']
+        });
 
         // prepare message object
         let messageData = {
@@ -716,24 +712,23 @@ class MessageHandler {
                                 await Promise.all(auditPromises);
                             };
 
-                            // can safely cleanup, no err given. Returns pending promise, which is fine
-                            const cleanupRes = cleanup(null, true, {
-                                uidValidity,
-                                uid,
-                                id: messageData._id.toString(),
-                                mailbox: mailboxData._id.toString(),
-                                mailboxPath: mailboxData.path,
-                                size,
-                                status: 'new',
-                                prepared
-                            });
-
                             // do not use more suitable finally as it is not supported in Node v8
-                            processAudits()
-                                .then(() => resolve(cleanupRes))
-                                .catch(() => resolve(cleanupRes));
+                            processAudits();
                         }
                     );
+                    // can safely cleanup, no err given. Returns pending promise, which is fine
+                    const cleanupRes = cleanup(null, true, {
+                        uidValidity,
+                        uid,
+                        id: messageData._id.toString(),
+                        mailbox: mailboxData._id.toString(),
+                        mailboxPath: mailboxData.path,
+                        size,
+                        status: 'new',
+                        prepared
+                    });
+
+                    return resolve(cleanupRes);
                 });
 
         if (


### PR DESCRIPTION
This is a proposal PR to look at the possibility of making storeNodeBodies and addEntries calls in addAsync non-blocking in order to speed up the process of saving messages.