### PR TITLE
fix(docker): Remove --platform=${BUILDPLATFORM} from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} node:lts-alpine
+FROM node:lts-alpine
 ARG TARGETPLATFORM
 ARG TARGETARCH
 ARG TARGETVARIANT


### PR DESCRIPTION
## Summary

- Removes `--platform=${BUILDPLATFORM}` from the Dockerfile `FROM` instruction, which causes issues when building for amd64 on ARM hosts (e.g. Apple Silicon). Without this flag, Docker correctly builds for the target platform.