### PR TITLE
fix(api): Fix $text search timeout and rename DB_MAX_TIME_MESSAGES_SEARCH

### DIFF
--- a/lib/api/messages.js
+++ b/lib/api/messages.js
@@ -870,6 +870,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                 query = prepared.query;
             }
 
+            let isTextSearch = filter && filter.$text;
             let total = await getFilteredMessageCount(filter);
             log.verbose('API', 'Searching %s', JSON.stringify(filter));
 
@@ -902,7 +903,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                         flags: true,
                         verificationResults: true
                     },
-                    maxTimeMS: consts.DB_MAX_TIME_MESSAGES_SEARCH
+                    maxTimeMS: isTextSearch ? consts.DB_MAX_TIME_MESSAGES : consts.DB_MAX_TIME_FIELD_SEARCH
                 },
                 paginatedField: order !== undefined ? 'idate' : '_id',
                 sortAscending: order === 'asc' ? true : undefined
@@ -950,7 +951,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
             } catch (err) {
                 if (err.code === 50 && err.codeName === 'MaxTimeMSExpired') {
                     try {
-                        opts.maxTimeMS = consts.DB_MAX_TIME_MESSAGES;
+                        opts.fields.maxTimeMS = consts.DB_MAX_TIME_MESSAGES;
                         delete opts.query.mailbox; // query all mailboxes
 
                         if (pageNext) opts.next = pageNext;
@@ -972,7 +973,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                     } catch (error) {
                         res.status(500);
                         return res.json({
-                            error: 'MongoDB Error: ' + err.message,
+                            error: 'MongoDB Error: ' + error.message,
                             code: 'InternalDatabaseError'
                         });
                     }

--- a/lib/consts.js
+++ b/lib/consts.js
@@ -99,7 +99,7 @@ module.exports = {
     DB_MAX_TIME_USERS: 3 * 1000,
     DB_MAX_TIME_MAILBOXES: 3 * 1000,
     DB_MAX_TIME_MESSAGES: 2 * 60 * 1000,
-    DB_MAX_TIME_MESSAGES_SEARCH: 3 * 1000, // 3 seconds for user search
+    DB_MAX_TIME_FIELD_SEARCH: 3 * 1000, // 3 seconds for indexed search.* field queries
 
     // what is the max username part after wildcard
     MAX_ALLOWED_WILDCARD_LENGTH: 32,


### PR DESCRIPTION
## Summary

- Use longer timeout (`DB_MAX_TIME_MESSAGES`, 2min) for `$text` fulltext searches and shorter timeout (`DB_MAX_TIME_FIELD_SEARCH`, 3s) for indexed `search.*` field queries
- Fix retry error variable (`err` → `error`) in the MaxTimeMSExpired catch block
- Fix retry path setting `maxTimeMS` on wrong object (`opts` → `opts.fields`)
- Rename `DB_MAX_TIME_MESSAGES_SEARCH` → `DB_MAX_TIME_FIELD_SEARCH` for clarity

Without this fix, `$text` searches on large mailboxes crash with `MaxTimeMSExpired` after 3 seconds because they were using the short field-search timeout instead of the generous fulltext timeout.