### PR TITLE
ZMS-54-2: Add strict2fa setting

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -7,6 +7,11 @@
 # process title
 ident = "wildduck"
 
+# If true, /authenticate returns a short-lived 2FA nonce instead of a user token
+# when WildDuck-verifiable 2FA is enabled for the user. Set to false to keep the
+# legacy behavior where /authenticate returns the user token immediately.
+strict2fa = true
+
 # how many processes to start
 # either a number for specific process count or "cpus" for machine thread count
 processes = 1

--- a/lib/api/auth.js
+++ b/lib/api/auth.js
@@ -2,6 +2,7 @@
 
 const Joi = require('joi');
 const ObjectId = require('mongodb').ObjectId;
+const config = require('@zone-eu/wild-config');
 const tools = require('../tools');
 const roles = require('../roles');
 const { nextPageCursorSchema, previousPageCursorSchema, sessSchema, sessIPSchema, booleanSchema, usernameSchema } = require('../schemas');
@@ -176,7 +177,7 @@ module.exports = (db, server, userHandler) => {
                                 .description('If true then the account is flagged as requiring 2FA to be enabled'),
                             requirePasswordChange: booleanSchema.required().description('Indicates if account password has been reset and should be replaced'),
                             token: Joi.string().description(
-                                'If access token was requested and no WildDuck-verifiable 2FA challenge is required then this is the value to use as access token when making API requests on behalf of logged in user.'
+                                'If access token was requested and no WildDuck-verifiable 2FA challenge is required, or strict2fa is disabled, then this is the value to use as access token when making API requests on behalf of logged in user.'
                             ),
                             twoFactorNonce: Joi.string().hex().length(40).description('Short-lived nonce for completing 2FA authentication'),
                             totpNonce: Joi.string().hex().length(40).description('Short-lived nonce for completing TOTP authentication'),
@@ -280,7 +281,7 @@ module.exports = (db, server, userHandler) => {
                 try {
                     const pending2faMethods = Array.isArray(authData.require2fa) ? authData.require2fa.filter(method => method !== 'custom') : [];
 
-                    if (pending2faMethods.length) {
+                    if (config.strict2fa !== false && pending2faMethods.length) {
                         authResponse.twoFactorNonce = await userHandler.generatePending2faNonce(authData.user, {
                             methods: pending2faMethods,
                             tokenRequested: true
@@ -297,6 +298,18 @@ module.exports = (db, server, userHandler) => {
                         }
                     } else {
                         authResponse.token = await userHandler.generateAuthToken(authData.user);
+                        if (config.strict2fa === false && pending2faMethods.includes('totp')) {
+                            authResponse.totpNonce = await userHandler.generatePending2faNonce(authData.user, {
+                                methods: ['totp'],
+                                tokenRequested: false
+                            });
+
+                            if (!authResponse.totpNonce) {
+                                let err = new Error('Failed to create TOTP authentication nonce');
+                                err.code = 'AuthFailed';
+                                throw err;
+                            }
+                        }
                     }
                 } catch (err) {
                     let response = {

--- a/test/api/totp-nonce-test.js
+++ b/test/api/totp-nonce-test.js
@@ -6,11 +6,193 @@ const chai = require('chai');
 const crypto = require('crypto');
 const ObjectId = require('mongodb').ObjectId;
 const { Fido2Lib } = require('fido2-lib');
+const speakeasy = require('speakeasy');
+const config = require('@zone-eu/wild-config');
 
 const expect = chai.expect;
 chai.config.includeStack = true;
 
+const authRoutes = require('../../lib/api/auth');
 const UserHandler = require('../../lib/user-handler');
+
+function getAuthenticateRoute(userHandler) {
+    const routes = [];
+    const server = {
+        post(spec, handler) {
+            routes.push({ spec, handler });
+        },
+        del() {},
+        get() {}
+    };
+
+    authRoutes({}, server, userHandler);
+    return routes.find(route => route.spec.path === '/authenticate' && route.spec.name === 'authenticate');
+}
+
+function getResponse() {
+    return {
+        statusCode: 200,
+        body: false,
+        charSet() {
+            return this;
+        },
+        status(statusCode) {
+            this.statusCode = statusCode;
+            return this;
+        },
+        json(body) {
+            this.body = body;
+            return body;
+        }
+    };
+}
+
+function assertGranted(permission) {
+    if (!permission.granted) {
+        throw new Error('Missing privileges');
+    }
+}
+
+describe('Authenticate Strict 2FA Handling', function () {
+    this.timeout(10000); // eslint-disable-line no-invalid-this
+
+    let originalStrict2fa;
+
+    beforeEach(() => {
+        originalStrict2fa = config.strict2fa;
+    });
+
+    afterEach(() => {
+        config.strict2fa = originalStrict2fa;
+    });
+
+    it('should return a pending 2FA nonce instead of a token when strict2fa is enabled', async () => {
+        config.strict2fa = true;
+
+        const user = new ObjectId();
+        const twoFactorNonce = crypto.randomBytes(20).toString('hex');
+        const calls = [];
+
+        const route = getAuthenticateRoute({
+            asyncAuthenticate: async () => [
+                {
+                    user,
+                    username: 'totpuser',
+                    address: 'totpuser@example.com',
+                    scope: 'master',
+                    require2fa: ['totp'],
+                    require2faEnabled: true,
+                    requirePasswordChange: false
+                },
+                user
+            ],
+            generatePending2faNonce: async (authUser, data) => {
+                calls.push(['pending', authUser.toString(), data]);
+                return twoFactorNonce;
+            },
+            generateAuthToken: async () => {
+                throw new Error('generateAuthToken should not be called');
+            }
+        });
+
+        const res = getResponse();
+        await route.handler(
+            {
+                method: 'POST',
+                url: '/authenticate',
+                route: { spec: route.spec },
+                params: {
+                    username: 'totpuser',
+                    password: 'totpsecret',
+                    token: true
+                },
+                role: 'root',
+                validate: assertGranted
+            },
+            res
+        );
+
+        expect(res.statusCode).to.equal(200);
+        expect(res.body.token).to.not.exist;
+        expect(res.body.twoFactorNonce).to.equal(twoFactorNonce);
+        expect(res.body.totpNonce).to.equal(twoFactorNonce);
+        expect(calls).to.deep.equal([
+            [
+                'pending',
+                user.toString(),
+                {
+                    methods: ['totp'],
+                    tokenRequested: true
+                }
+            ]
+        ]);
+    });
+
+    it('should return a token and standalone TOTP nonce when strict2fa is disabled', async () => {
+        config.strict2fa = false;
+
+        const user = new ObjectId();
+        const accessToken = crypto.randomBytes(20).toString('hex');
+        const totpNonce = crypto.randomBytes(20).toString('hex');
+        const calls = [];
+
+        const route = getAuthenticateRoute({
+            asyncAuthenticate: async () => [
+                {
+                    user,
+                    username: 'legacytotpuser',
+                    address: 'legacytotpuser@example.com',
+                    scope: 'master',
+                    require2fa: ['totp'],
+                    require2faEnabled: true,
+                    requirePasswordChange: false
+                },
+                user
+            ],
+            generateAuthToken: async authUser => {
+                calls.push(['token', authUser.toString()]);
+                return accessToken;
+            },
+            generatePending2faNonce: async (authUser, data) => {
+                calls.push(['pending', authUser.toString(), data]);
+                return totpNonce;
+            }
+        });
+
+        const res = getResponse();
+        await route.handler(
+            {
+                method: 'POST',
+                url: '/authenticate',
+                route: { spec: route.spec },
+                params: {
+                    username: 'legacytotpuser',
+                    password: 'totpsecret',
+                    token: true
+                },
+                role: 'root',
+                validate: assertGranted
+            },
+            res
+        );
+
+        expect(res.statusCode).to.equal(200);
+        expect(res.body.token).to.equal(accessToken);
+        expect(res.body.twoFactorNonce).to.not.exist;
+        expect(res.body.totpNonce).to.equal(totpNonce);
+        expect(calls).to.deep.equal([
+            ['token', user.toString()],
+            [
+                'pending',
+                user.toString(),
+                {
+                    methods: ['totp'],
+                    tokenRequested: false
+                }
+            ]
+        ]);
+    });
+});
 
 describe('Pending 2FA Nonce Handling', function () {
     this.timeout(10000); // eslint-disable-line no-invalid-this
@@ -19,6 +201,11 @@ describe('Pending 2FA Nonce Handling', function () {
         const calls = [];
         const seed = 'JBSWY3DPEHPK3PXP';
         const user = new ObjectId();
+        const validToken = speakeasy.totp({
+            secret: seed,
+            encoding: 'base32'
+        });
+        const invalidToken = validToken === '000000' ? '000001' : '000000';
         const handler = {
             redis: {
                 exists: async () => 0,
@@ -67,12 +254,84 @@ describe('Pending 2FA Nonce Handling', function () {
         };
 
         const result = await UserHandler.prototype.checkTotp.call(handler, user, {
-            token: '000000',
+            token: invalidToken,
             totpNonce: crypto.randomBytes(20).toString('hex')
         });
 
         expect(result).to.be.false;
         expect(calls).to.deep.equal(['consumePending', 'restore:pending2fa:test']);
+    });
+
+    it('should restore the standalone TOTP nonce after a failed TOTP verification when strict2fa is disabled', async () => {
+        const originalStrict2fa = config.strict2fa;
+        config.strict2fa = false;
+
+        try {
+            const calls = [];
+            const seed = 'JBSWY3DPEHPK3PXP';
+            const user = new ObjectId();
+            const validToken = speakeasy.totp({
+                secret: seed,
+                encoding: 'base32'
+            });
+            const invalidToken = validToken === '000000' ? '000001' : '000000';
+            const handler = {
+                redis: {
+                    exists: async () => 0,
+                    multi() {
+                        return {
+                            set() {
+                                return this;
+                            },
+                            expire() {
+                                return this;
+                            },
+                            exec: async () => []
+                        };
+                    }
+                },
+                users: {
+                    collection() {
+                        return {
+                            findOne: async () => ({
+                                enabled2fa: ['totp'],
+                                seed
+                            })
+                        };
+                    }
+                },
+                rateLimit: async () => ({ success: true }),
+                rateLimitReleaseUser: async () => false,
+                logAuthEvent: async () => false,
+                consumePending2faAuth: async () => {
+                    calls.push('consumePending');
+                    return {
+                        user,
+                        key: 'pending2fa:test',
+                        data: {
+                            user: user.toString(),
+                            methods: '["totp"]',
+                            tokenRequested: 'false'
+                        },
+                        expires: Date.now() + 5 * 60 * 1000
+                    };
+                },
+                restorePending2faAuth: async consumedPending2faAuth => {
+                    calls.push(`restore:${consumedPending2faAuth.key}`);
+                    return true;
+                }
+            };
+
+            const result = await UserHandler.prototype.checkTotp.call(handler, user, {
+                token: invalidToken,
+                totpNonce: crypto.randomBytes(20).toString('hex')
+            });
+
+            expect(result).to.be.false;
+            expect(calls).to.deep.equal(['consumePending', 'restore:pending2fa:test']);
+        } finally {
+            config.strict2fa = originalStrict2fa;
+        }
     });
 
     it('should validate and consume a pending 2FA nonce, then restore it with the remaining TTL', async () => {


### PR DESCRIPTION
This allows to make the last ZMS-54 change less breaking by supporting legacy 2fa verification flow