### PR TITLE
Clean up and unify encrypted message logging

### DIFF
--- a/lib/api/messages.js
+++ b/lib/api/messages.js
@@ -2574,9 +2574,15 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                     if (encryptResult) {
                         raw = encryptResult.raw;
                     } else {
-                        log.error('ENCRYPT', 'Encryption returned false for user %s, message stored unencrypted (source: api_messages)', user);
+                        log.error(
+                            'ENCRYPT',
+                            'Encryption returned false, message stored unencrypted (source=%s user=%s ip=%s)',
+                            'api_messages',
+                            user,
+                            result.value.ip || req.remoteAddress
+                        );
                         server.loggelf({
-                            short_message: '[ENCRYPTSKIP] Encryption returned false during API message upload',
+                            short_message: '[ENCRYPTSKIP] Encryption returned false, message stored unencrypted',
                             _mail_action: 'encrypt_skip',
                             _user: user,
                             _ip: result.value.ip || req.remoteAddress,
@@ -2584,8 +2590,17 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                         });
                     }
                 } catch (err) {
+                    log.error(
+                        'ENCRYPT',
+                        'Encryption failed, message stored unencrypted (source=%s user=%s ip=%s code=%s): %s',
+                        'api_messages',
+                        user,
+                        result.value.ip || req.remoteAddress,
+                        err.code || 'EncryptionError',
+                        err.message
+                    );
                     server.loggelf({
-                        short_message: '[ENCRYPTFAIL] Encryption failed during API message upload',
+                        short_message: '[ENCRYPTFAIL] Encryption failed, message stored unencrypted',
                         _mail_action: 'encrypt_fail',
                         _user: user,
                         _error: err.message,

--- a/lib/api/submit.js
+++ b/lib/api/submit.js
@@ -547,11 +547,14 @@ module.exports = (db, server, messageHandler, userHandler, settingsHandler) => {
                                                 } else {
                                                     log.error(
                                                         'ENCRYPT',
-                                                        'Encryption returned false for user %s, message stored unencrypted (source: api_submit)',
-                                                        userData._id
+                                                        'Encryption returned false, message stored unencrypted (source=%s user=%s ip=%s sess=%s)',
+                                                        'api_submit',
+                                                        userData._id,
+                                                        options.ip,
+                                                        options.sess
                                                     );
                                                     server.loggelf({
-                                                        short_message: '[ENCRYPTFAIL] Encryption returned false during API submit',
+                                                        short_message: '[ENCRYPTSKIP] Encryption returned false, message stored unencrypted',
                                                         _mail_action: 'encrypt_skip',
                                                         _user: userData._id,
                                                         _ip: options.ip,
@@ -560,8 +563,18 @@ module.exports = (db, server, messageHandler, userHandler, settingsHandler) => {
                                                     });
                                                 }
                                             } catch (err) {
+                                                log.error(
+                                                    'ENCRYPT',
+                                                    'Encryption failed, message stored unencrypted (source=%s user=%s ip=%s sess=%s code=%s): %s',
+                                                    'api_submit',
+                                                    userData._id,
+                                                    options.ip,
+                                                    options.sess,
+                                                    err.code || 'EncryptionError',
+                                                    err.message
+                                                );
                                                 server.loggelf({
-                                                    short_message: '[ENCRYPTFAIL] Encryption failed during API submit',
+                                                    short_message: '[ENCRYPTFAIL] Encryption failed, message stored unencrypted',
                                                     _mail_action: 'encrypt_fail',
                                                     _user: userData._id,
                                                     _error: err.message,

--- a/lib/filter-handler.js
+++ b/lib/filter-handler.js
@@ -385,17 +385,25 @@ class FilterHandler {
                     });
                     maildata = this.messageHandler.indexer.getMaildata(prepared.mimeTree);
                 } else {
-                    log.error('ENCRYPT', 'Encryption returned false for user %s, message stored unencrypted (source: filter_handler)', userData._id);
+                    log.error('ENCRYPT', 'Encryption returned false, message stored unencrypted (source=%s user=%s)', 'filter_handler', userData._id);
                     this.loggelf({
-                        short_message: '[ENCRYPTSKIP] Encryption returned false during message filtering',
+                        short_message: '[ENCRYPTSKIP] Encryption returned false, message stored unencrypted',
                         _mail_action: 'encrypt_skip',
                         _user: userData._id,
                         _source: 'filter_handler'
                     });
                 }
             } catch (err) {
+                log.error(
+                    'ENCRYPT',
+                    'Encryption failed, message stored unencrypted (source=%s user=%s code=%s): %s',
+                    'filter_handler',
+                    userData._id,
+                    err.code || 'EncryptionError',
+                    err.message
+                );
                 this.loggelf({
-                    short_message: '[ENCRYPTFAIL] Encryption failed during message filtering',
+                    short_message: '[ENCRYPTFAIL] Encryption failed, message stored unencrypted',
                     _mail_action: 'encrypt_fail',
                     _user: userData._id,
                     _error: err.message,

--- a/lib/handlers/on-append.js
+++ b/lib/handlers/on-append.js
@@ -72,12 +72,13 @@ module.exports = (server, messageHandler, userCache) => (path, flags, date, raw,
                                         } else {
                                             server.logger.error(
                                                 { tnx: 'encrypt', cid: session.id },
-                                                '[%s] Encryption returned false for user %s, message stored unencrypted',
+                                                '[%s] Encryption returned false, message stored unencrypted (source=%s user=%s)',
                                                 session.id,
+                                                'imap_append',
                                                 session.user.id
                                             );
                                             server.loggelf({
-                                                short_message: '[ENCRYPTSKIP] Encryption returned false during IMAP APPEND',
+                                                short_message: '[ENCRYPTSKIP] Encryption returned false, message stored unencrypted',
                                                 _mail_action: 'encrypt_skip',
                                                 _user: session.user.id,
                                                 _sess: session && session.id,
@@ -85,8 +86,17 @@ module.exports = (server, messageHandler, userCache) => (path, flags, date, raw,
                                             });
                                         }
                                     } catch (err) {
+                                        server.logger.error(
+                                            { tnx: 'encrypt', cid: session.id },
+                                            '[%s] Encryption failed, message stored unencrypted (source=%s user=%s code=%s): %s',
+                                            session.id,
+                                            'imap_append',
+                                            session.user.id,
+                                            err.code || 'EncryptionError',
+                                            err.message
+                                        );
                                         server.loggelf({
-                                            short_message: '[ENCRYPTFAIL] Encryption failed during IMAP APPEND',
+                                            short_message: '[ENCRYPTFAIL] Encryption failed, message stored unencrypted',
                                             _mail_action: 'encrypt_fail',
                                             _user: session.user.id,
                                             _error: err.message,

--- a/lib/handlers/on-copy.js
+++ b/lib/handlers/on-copy.js
@@ -236,12 +236,13 @@ async function copyHandler(server, messageHandler, connection, mailbox, update, 
                     } else {
                         server.logger.error(
                             { tnx: 'encrypt', cid: session.id },
-                            '[%s] Encryption returned false for user %s, message stored unencrypted',
+                            '[%s] Encryption returned false, message stored unencrypted (source=%s user=%s)',
                             session.id,
+                            'imap_copy',
                             session.user.id
                         );
                         server.loggelf({
-                            short_message: '[ENCRYPTSKIP] Encryption returned false during IMAP COPY',
+                            short_message: '[ENCRYPTSKIP] Encryption returned false, message stored unencrypted',
                             _mail_action: 'encrypt_skip',
                             _user: session.user.id,
                             _sess: session && session.id,
@@ -249,8 +250,17 @@ async function copyHandler(server, messageHandler, connection, mailbox, update, 
                         });
                     }
                 } catch (err) {
+                    server.logger.error(
+                        { tnx: 'encrypt', cid: session.id },
+                        '[%s] Encryption failed, message stored unencrypted (source=%s user=%s code=%s): %s',
+                        session.id,
+                        'imap_copy',
+                        session.user.id,
+                        err.code || 'EncryptionError',
+                        err.message
+                    );
                     server.loggelf({
-                        short_message: '[ENCRYPTFAIL] Encryption failed during IMAP COPY',
+                        short_message: '[ENCRYPTFAIL] Encryption failed, message stored unencrypted',
                         _mail_action: 'encrypt_fail',
                         _user: session.user.id,
                         _error: err.message,

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -277,9 +277,9 @@ class MessageHandler {
             if (encryptResult) {
                 options.raw = encryptResult.raw;
             } else {
-                log.error('ENCRYPT', 'Encryption returned false for user %s, message stored unencrypted (source: add)', userData._id);
+                log.error('ENCRYPT', 'Encryption returned false, message stored unencrypted (source=%s user=%s)', 'message_add', userData._id);
                 this.loggelf({
-                    short_message: '[ENCRYPTSKIP] Encryption returned false during message add',
+                    short_message: '[ENCRYPTSKIP] Encryption returned false, message stored unencrypted',
                     _mail_action: 'encrypt_skip',
                     _user: userData._id,
                     _source: 'message_add'
@@ -1183,9 +1183,9 @@ class MessageHandler {
                         message.envelope = result.prepared.envelope;
                         message.headers = result.prepared.headers;
                     } else {
-                        log.error('ENCRYPT', 'Encryption returned false for user %s, message stored unencrypted (source: move)', mailboxData.user);
+                        log.error('ENCRYPT', 'Encryption returned false, message stored unencrypted (source=%s user=%s)', 'imap_move', mailboxData.user);
                         this.loggelf({
-                            short_message: '[ENCRYPTSKIP] Encryption returned false during IMAP MOVE',
+                            short_message: '[ENCRYPTSKIP] Encryption returned false, message stored unencrypted',
                             _mail_action: 'encrypt_skip',
                             _user: mailboxData.user,
                             _source: 'imap_move'

--- a/lib/user-handler.js
+++ b/lib/user-handler.js
@@ -4063,17 +4063,25 @@ class UserHandler {
                     if (encryptResult) {
                         message = encryptResult.raw;
                     } else {
-                        log.error('ENCRYPT', 'Encryption returned false for user %s, welcome message stored unencrypted', userData._id);
+                        log.error('ENCRYPT', 'Encryption returned false, message stored unencrypted (source=%s user=%s)', 'welcome_message', userData._id);
                         this.loggelf({
-                            short_message: '[ENCRYPTSKIP] Encryption returned false during welcome message',
+                            short_message: '[ENCRYPTSKIP] Encryption returned false, message stored unencrypted',
                             _mail_action: 'encrypt_skip',
                             _user: userData._id,
                             _source: 'welcome_message'
                         });
                     }
                 } catch (err) {
+                    log.error(
+                        'ENCRYPT',
+                        'Encryption failed, message stored unencrypted (source=%s user=%s code=%s): %s',
+                        'welcome_message',
+                        userData._id,
+                        err.code || 'EncryptionError',
+                        err.message
+                    );
                     this.loggelf({
-                        short_message: '[ENCRYPTFAIL] Encryption failed during welcome message',
+                        short_message: '[ENCRYPTFAIL] Encryption failed, message stored unencrypted',
                         _mail_action: 'encrypt_fail',
                         _user: userData._id,
                         _error: err.message,


### PR DESCRIPTION
Some of the S/MIME log lines didn't have a non-GELF equivalent or they were just worded differently.