### PR TITLE
Duplicate References and In-Reply-To onto encrypted envelope for thread visibility

### DIFF
--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -29,7 +29,19 @@ openpgp.config.versionString = `WildDuck v${packageData.version}`;
 
 // Headers duplicated on the outer envelope for UX/UI purposes (like BIMI-* or Subject).
 // Non-listed headers will only reside in the encrypted body for privacy.
-const OUTER_HEADER_NAMES = ['date', 'subject', 'from', 'to', 'message-id', 'mime-version', 'bimi-location', 'bimi-indicator', 'authentication-results'];
+const OUTER_HEADER_NAMES = [
+    'date',
+    'subject',
+    'from',
+    'to',
+    'message-id',
+    'mime-version',
+    'bimi-location',
+    'bimi-indicator',
+    'authentication-results',
+    'references',
+    'in-reply-to'
+];
 
 // RFC 2045 §6.8: base64-encoded lines MUST be no longer than 76 characters.
 const TARGET_LINE_LENGTH = 76;


### PR DESCRIPTION
Both headers rely on "Message-ID" or are logged elsewhere, so this doesn't really result in a significant privacy leak, but they fix threading in MUAs.