### PR TITLE
ZMS-68: Encrypted mail accounting, storage and copy IMAP fixes

### DIFF
--- a/lib/handlers/on-copy.js
+++ b/lib/handlers/on-copy.js
@@ -135,6 +135,27 @@ async function copyHandler(server, messageHandler, connection, mailbox, update, 
 
     let targetEncrypted = !!(targetData.encryptMessages || userData.encryptMessages);
 
+    // Release refs established for a destination message whose insert failed (encrypted bodies from
+    // storeNodeBodies(), or the plaintext +1), so the GridFS rows are not leaked.
+    let releaseRefs = async (attachmentIds, magic) => {
+        if (!attachmentIds || !attachmentIds.length) {
+            return;
+        }
+        try {
+            await messageHandler.attachmentStorage.deleteManyAsync(attachmentIds, magic);
+        } catch (err) {
+            server.loggelf({
+                short_message: '[COPYATTACHFAIL] Failed to release attachments after failed IMAP COPY insert',
+                _mail_action: 'copy_attach_fail',
+                _user: session.user.id,
+                _error: err.message,
+                _code: err.code || 'AttachmentReleaseError',
+                _sess: session && session.id,
+                _source: 'imap_copy'
+            });
+        }
+    };
+
     try {
         while ((messageData = await cursor.next())) {
             tools.checkSocket(socket); // do we even have to copy anything?
@@ -147,8 +168,10 @@ async function copyHandler(server, messageHandler, connection, mailbox, update, 
 
             const isAlreadyEncrypted = MessageHandler.isMessageEncrypted(messageHandler._getContentType(messageData.mimeTree));
 
+            // Capture the source UID before messageData.uid is reassigned to the destination UID
+            let sourceUidValue = messageData.uid;
+
             // Copying is not done in bulk to minimize risk of going out of sync with incremental UIDs
-            sourceUid.unshift(messageData.uid);
             let item = await db.database.collection('mailboxes').findOneAndUpdate(
                 {
                     _id: targetData._id
@@ -175,7 +198,6 @@ async function copyHandler(server, messageHandler, connection, mailbox, update, 
 
             let uidNext = item.value.uidNext;
             let modifyIndex = item.value.modifyIndex;
-            destinationUid.unshift(uidNext);
 
             messageData._id = new ObjectId();
             messageData.mailbox = targetData._id;
@@ -211,17 +233,6 @@ async function copyHandler(server, messageHandler, connection, mailbox, update, 
                 time: new Date()
             });
 
-            await db.database.collection('messages').updateOne(
-                existingQuery,
-                {
-                    $set: {
-                        // indicate that we do not need to archive this message when deleted
-                        copied: true
-                    }
-                },
-                { writeConcern: 'majority' }
-            );
-
             let newPrepared = false;
             let encryptionKey = targetEncrypted && !isAlreadyEncrypted && tools.getUserEncryptionKey(userData);
             if (encryptionKey) {
@@ -232,8 +243,11 @@ async function copyHandler(server, messageHandler, connection, mailbox, update, 
                         messageData.attachments = result.maildata.attachments || [];
                         messageData.ha = (result.maildata.attachments || []).some(a => !a.related);
                         delete messageData.text;
+                        delete messageData.textFooter;
                         delete messageData.html;
                         messageData.intro = '';
+                        // expunge-time refcount decrement matches attachments by magic, so persist the magic storeNodeBodies() assigned
+                        messageData.magic = result.maildata.magic;
                     } else {
                         server.logger.error(
                             { tnx: 'encrypt', cid: session.id },
@@ -281,24 +295,72 @@ async function copyHandler(server, messageHandler, connection, mailbox, update, 
                 messageData.headers = newPrepared.headers;
             }
 
-            let r = await db.database.collection('messages').insertOne(messageData, { writeConcern: 'majority' });
-
-            if (!r || !r.acknowledged) {
-                continue;
-            }
-
-            copiedMessages++;
-            copiedStorage += Number(messageData.size) || 0;
-
+            // Establish attachment refs before inserting the destination message so a failed insert
+            // can never leave an under-counted (plaintext) or orphaned (encrypted) GridFS row.
             let attachmentIds = Object.keys(messageData.mimeTree.attachmentMap || {}).map(key => messageData.mimeTree.attachmentMap[key]);
 
-            if (attachmentIds.length) {
+            // encrypted copies already had their refcount set by storeNodeBodies(); only plaintext needs +1
+            if (!newPrepared && attachmentIds.length) {
                 try {
                     await messageHandler.attachmentStorage.updateMany(attachmentIds, 1, messageData.magic);
                 } catch (err) {
-                    // should we care about this error?
+                    // skip rather than store a copy whose attachments could be reclaimed while referenced
+                    server.loggelf({
+                        short_message: '[COPYREFFAIL] Failed to increment attachment refcount during IMAP COPY',
+                        _mail_action: 'copy_ref_fail',
+                        _user: session.user.id,
+                        _error: err.message,
+                        _code: err.code || 'AttachmentUpdateError',
+                        _sess: session && session.id,
+                        _source: 'imap_copy'
+                    });
+                    continue;
                 }
             }
+
+            let r;
+            try {
+                r = await db.database.collection('messages').insertOne(messageData, { writeConcern: 'majority' });
+            } catch (err) {
+                // release the refs we just established so a failed insert does not leak GridFS rows
+                await releaseRefs(attachmentIds, messageData.magic);
+                throw err;
+            }
+
+            if (!r || !r.acknowledged) {
+                await releaseRefs(attachmentIds, messageData.magic);
+                continue;
+            }
+
+            // Mark source as copied (skip archive-on-delete) only after a confirmed insert, so a failed
+            // copy keeps its safety net. Non-fatal: the copy is durable, so don't abort/desync on error.
+            try {
+                await db.database.collection('messages').updateOne(
+                    existingQuery,
+                    {
+                        $set: {
+                            copied: true
+                        }
+                    },
+                    { writeConcern: 'majority' }
+                );
+            } catch (err) {
+                server.loggelf({
+                    short_message: '[COPYFLAGFAIL] Failed to mark source copied after successful IMAP COPY',
+                    _mail_action: 'copy_flag_fail',
+                    _user: session.user.id,
+                    _error: err.message,
+                    _code: err.code || 'CopyFlagError',
+                    _sess: session && session.id,
+                    _source: 'imap_copy'
+                });
+            }
+
+            sourceUid.unshift(sourceUidValue);
+            destinationUid.unshift(uidNext);
+
+            copiedMessages++;
+            copiedStorage += Number(messageData.size) || 0;
 
             let entry = {
                 command: 'EXISTS',
@@ -324,7 +386,7 @@ async function copyHandler(server, messageHandler, connection, mailbox, update, 
         await updateQuota();
     }
 
-    server.notifier.fire(session.user.id, targetData.path);
+    server.notifier.fire(session.user.id);
     return [
         true,
         {

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -1190,13 +1190,24 @@ class MessageHandler {
 
             const bulk_batch_size = await this.settingsHandler.get('const:max:bulk_batch_size', {});
 
+            // updateMessage()'s raw deleteOne doesn't release source attachments or adjust quota
+            let encryptedMoveCleanup = null;
+
+            // new encrypted-body refs, released by updateMessage() only if the destination insert fails
+            let encryptedInsertCleanup = null;
+
             if (moveEncryptionKey && !MessageHandler.isMessageEncrypted(this._getContentType(message.mimeTree))) {
                 try {
+                    let oldAttachmentIds = Object.keys(message.mimeTree.attachmentMap || {}).map(k => message.mimeTree.attachmentMap[k]);
+                    let oldMagic = message.magic;
+                    let oldSize = Number(message.size) || 0;
+
                     let result = await this.encryptAndPrepareMessageAsync(message.mimeTree, moveEncryptionKey);
                     if (result) {
                         message.attachments = result.maildata.attachments || [];
-                        message.ha = true;
+                        message.ha = (result.maildata.attachments || []).some(a => !a.related);
                         delete message.text;
+                        delete message.textFooter;
                         delete message.html;
                         message.intro = '';
                         message.mimeTree = result.prepared.mimeTree;
@@ -1204,6 +1215,18 @@ class MessageHandler {
                         message.bodystructure = result.prepared.bodystructure;
                         message.envelope = result.prepared.envelope;
                         message.headers = result.prepared.headers;
+                        message.magic = result.maildata.magic;
+
+                        encryptedMoveCleanup = {
+                            oldAttachmentIds,
+                            oldMagic,
+                            sizeDelta: (Number(message.size) || 0) - oldSize
+                        };
+
+                        encryptedInsertCleanup = {
+                            newAttachmentIds: Object.keys(result.prepared.mimeTree.attachmentMap || {}).map(k => result.prepared.mimeTree.attachmentMap[k]),
+                            newMagic: result.maildata.magic
+                        };
                     } else {
                         log.error('ENCRYPT', 'Encryption returned false, message stored unencrypted (source=%s user=%s)', 'imap_move', mailboxData.user);
                         this.loggelf({
@@ -1233,11 +1256,70 @@ class MessageHandler {
                     newModseq,
                     uidNext,
                     junk,
-                    bulk_batch_size
+                    bulk_batch_size,
+                    encryptedInsertCleanup
                 },
                 cursor,
                 options
             );
+
+            if (encryptedMoveCleanup) {
+                if (encryptedMoveCleanup.oldAttachmentIds.length) {
+                    try {
+                        await this.attachmentStorage.deleteManyAsync(encryptedMoveCleanup.oldAttachmentIds, encryptedMoveCleanup.oldMagic);
+                    } catch (err) {
+                        log.error(
+                            'MOVE',
+                            'Failed to release source attachments after encrypted move (source=%s user=%s mailbox=%s code=%s): %s',
+                            'imap_move',
+                            mailboxData.user,
+                            targetData._id,
+                            err.code || 'AttachmentReleaseError',
+                            err.message
+                        );
+                        this.loggelf({
+                            short_message: '[MOVEATTACHFAIL] Failed to release source attachments after encrypted move',
+                            _mail_action: 'move_attach_fail',
+                            _user: mailboxData.user,
+                            _mailbox: targetData._id,
+                            _error: err.message,
+                            _code: err.code || 'AttachmentReleaseError',
+                            _source: 'imap_move'
+                        });
+                    }
+                }
+
+                if (encryptedMoveCleanup.sizeDelta) {
+                    try {
+                        await this.updateQuotaAsync(
+                            mailboxData.user,
+                            { storageUsed: encryptedMoveCleanup.sizeDelta, mailbox: targetData._id },
+                            options
+                        );
+                    } catch (err) {
+                        log.error(
+                            'MOVE',
+                            'Failed to adjust storageUsed after encrypted move (source=%s user=%s mailbox=%s delta=%s code=%s): %s',
+                            'imap_move',
+                            mailboxData.user,
+                            targetData._id,
+                            encryptedMoveCleanup.sizeDelta,
+                            err.code || 'QuotaUpdateError',
+                            err.message
+                        );
+                        this.loggelf({
+                            short_message: '[MOVEQUOTAFAIL] Failed to adjust storageUsed after encrypted move',
+                            _mail_action: 'move_quota_fail',
+                            _user: mailboxData.user,
+                            _mailbox: targetData._id,
+                            _delta: encryptedMoveCleanup.sizeDelta,
+                            _error: err.message,
+                            _code: err.code || 'QuotaUpdateError',
+                            _source: 'imap_move'
+                        });
+                    }
+                }
+            }
         }
     }
 
@@ -2181,8 +2263,31 @@ class MessageHandler {
             newModseq,
             uidNext,
             junk,
-            bulk_batch_size
+            bulk_batch_size,
+            encryptedInsertCleanup
         } = data;
+
+        // Release the newly encrypted bodies only when the insert didn't store the doc. Never after a
+        // successful insert (e.g. a later source-delete failure): the destination is then live and owns them.
+        let releaseEncryptedInsertRefs = async () => {
+            if (!encryptedInsertCleanup || !encryptedInsertCleanup.newAttachmentIds || !encryptedInsertCleanup.newAttachmentIds.length) {
+                return;
+            }
+            try {
+                await this.attachmentStorage.deleteManyAsync(encryptedInsertCleanup.newAttachmentIds, encryptedInsertCleanup.newMagic);
+            } catch (err) {
+                log.error('MOVE', 'Failed to release encrypted attachments after failed destination insert (source=imap_move code=%s): %s', err.code || 'AttachmentReleaseError', err.message);
+                this.loggelf({
+                    short_message: '[MOVEATTACHFAIL] Failed to release encrypted attachments after failed destination insert',
+                    _mail_action: 'move_attach_fail',
+                    _user: mailboxData.user,
+                    _mailbox: targetData._id,
+                    _error: err.message,
+                    _code: err.code || 'AttachmentReleaseError',
+                    _source: 'imap_move'
+                });
+            }
+        };
 
         try {
             r = await this.database.collection('messages').insertOne(message, { writeConcern: 'majority' });
@@ -2192,10 +2297,12 @@ class MessageHandler {
                 err.responseCode = 500;
                 err.code = 'StoreError';
 
+                await releaseEncryptedInsertRefs();
                 await cursor.close();
                 return this.moveDone(err, { targetData, sourceUid, destinationUid, mailboxData, existsEntries, removeEntries }, options); // will throw
             }
         } catch (err) {
+            await releaseEncryptedInsertRefs();
             await cursor.close();
             return this.moveDone(err, { targetData, sourceUid, destinationUid, mailboxData, existsEntries, removeEntries }, options); // will throw
         }

--- a/test/move-quota-test.js
+++ b/test/move-quota-test.js
@@ -1,0 +1,307 @@
+/* eslint no-unused-expressions: 0, prefer-arrow-callback: 0 */
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+const { ObjectId } = require('mongodb');
+
+const MessageHandler = require('../lib/message-handler');
+
+describe('moveAsync - encrypted-MOVE quota adjustment', function () {
+    let insertedDocs;
+
+    // Build a MessageHandler whose destination insert / source delete behaviour is configurable,
+    // with a spy on attachmentStorage.deleteManyAsync. The encrypted form carries one attachment
+    // (enc-id-1 / new-magic) so the new-ref cleanup has something to release.
+    function buildEncryptedMoveHandler({ insertOneImpl, deleteOneImpl }) {
+        const userId = new ObjectId();
+        const sourceMailboxId = new ObjectId();
+        const targetMailboxId = new ObjectId();
+        const messageId = new ObjectId();
+
+        const sourceMessage = {
+            _id: messageId,
+            mailbox: sourceMailboxId,
+            uid: 1,
+            size: 1000,
+            magic: 'old-magic',
+            unseen: false,
+            flags: [],
+            // empty source attachmentMap keeps the old-ref cleanup out of the picture
+            mimeTree: { header: [], attachmentMap: {} }
+        };
+
+        let cursorIdx = 0;
+        let calls = { deleteManyAsync: [], insertOne: [] };
+
+        let handler = Object.create(MessageHandler.prototype);
+        handler.loggelf = () => {};
+
+        handler.database = {
+            collection: name => {
+                if (name === 'mailboxes') {
+                    return {
+                        findOne: query => {
+                            if (query._id && query._id.equals && query._id.equals(sourceMailboxId)) {
+                                return Promise.resolve({ _id: sourceMailboxId, user: userId, path: 'INBOX', uidValidity: 100 });
+                            }
+                            if (query._id && query._id.equals && query._id.equals(targetMailboxId)) {
+                                return Promise.resolve({ _id: targetMailboxId, user: userId, path: 'Vault', uidValidity: 200, encryptMessages: true });
+                            }
+                            return Promise.resolve(null);
+                        },
+                        findOneAndUpdate: () => Promise.resolve({ value: { uidNext: 1, modifyIndex: 1 } })
+                    };
+                }
+                if (name === 'messages') {
+                    return {
+                        find: () => ({
+                            sort: () => ({
+                                next: () => Promise.resolve(cursorIdx++ === 0 ? sourceMessage : null),
+                                close: () => Promise.resolve()
+                            })
+                        }),
+                        insertOne: doc => {
+                            calls.insertOne.push(doc);
+                            return insertOneImpl(doc, calls.insertOne.length);
+                        },
+                        deleteOne: () => (deleteOneImpl ? deleteOneImpl() : Promise.resolve({ deletedCount: 1 }))
+                    };
+                }
+                throw new Error('unexpected handler.database.collection: ' + name);
+            }
+        };
+
+        handler.users = {
+            collection: () => ({
+                findOne: () => Promise.resolve({ _id: userId, encryptMessages: true, smimeCerts: ['fake-cert'] }),
+                findOneAndUpdate: () => Promise.resolve({ value: { storageUsed: 100 } })
+            })
+        };
+
+        handler.settingsHandler = { get: () => Promise.resolve(100) };
+        handler.notifier = {
+            addEntries: (mailbox, entries, cb) => {
+                if (cb) {
+                    return cb();
+                }
+            },
+            fire: () => {}
+        };
+        handler.indexer = { getMaildata: () => ({ attachments: [], magic: 'new-magic' }) };
+        handler.attachmentStorage = {
+            deleteManyAsync: (ids, magic) => {
+                calls.deleteManyAsync.push({ ids, magic });
+                return Promise.resolve();
+            }
+        };
+        handler.encryptAndPrepareMessageAsync = () =>
+            Promise.resolve({
+                prepared: {
+                    mimeTree: { header: [], attachmentMap: { '1': 'enc-id-1' } },
+                    size: 1500,
+                    bodystructure: {},
+                    envelope: {},
+                    headers: {}
+                },
+                maildata: { attachments: [], magic: 'new-magic' },
+                type: 'smime'
+            });
+
+        return { handler, calls, sourceMailboxId, targetMailboxId };
+    }
+
+    async function runMove(handler, sourceMailboxId, targetMailboxId) {
+        let err;
+        try {
+            await handler.moveAsync({
+                source: { mailbox: sourceMailboxId },
+                destination: { mailbox: targetMailboxId },
+                messages: [1]
+            });
+        } catch (e) {
+            err = e;
+        }
+        return err;
+    }
+
+    it('releases newly encrypted attachments when the destination insert is not acknowledged', async function () {
+        let { handler, calls, sourceMailboxId, targetMailboxId } = buildEncryptedMoveHandler({
+            insertOneImpl: () => Promise.resolve({ acknowledged: false })
+        });
+
+        let err = await runMove(handler, sourceMailboxId, targetMailboxId);
+
+        expect(err).to.be.an('error');
+        expect(calls.deleteManyAsync).to.have.lengthOf(1);
+        expect(calls.deleteManyAsync[0].ids).to.deep.equal(['enc-id-1']);
+        expect(calls.deleteManyAsync[0].magic).to.equal('new-magic');
+    });
+
+    it('releases newly encrypted attachments when the destination insert throws', async function () {
+        let { handler, calls, sourceMailboxId, targetMailboxId } = buildEncryptedMoveHandler({
+            insertOneImpl: () => Promise.reject(Object.assign(new Error('insert boom'), { code: 'StoreError' }))
+        });
+
+        let err = await runMove(handler, sourceMailboxId, targetMailboxId);
+
+        expect(err).to.be.an('error');
+        expect(calls.deleteManyAsync).to.have.lengthOf(1);
+        expect(calls.deleteManyAsync[0].ids).to.deep.equal(['enc-id-1']);
+        expect(calls.deleteManyAsync[0].magic).to.equal('new-magic');
+    });
+
+    it('does NOT release newly encrypted attachments when the source delete fails after a successful insert', async function () {
+        let { handler, calls, sourceMailboxId, targetMailboxId } = buildEncryptedMoveHandler({
+            insertOneImpl: () => Promise.resolve({ acknowledged: true, insertedId: new ObjectId() }),
+            deleteOneImpl: () => Promise.reject(Object.assign(new Error('delete boom'), { code: 'DeleteError' }))
+        });
+
+        let err = await runMove(handler, sourceMailboxId, targetMailboxId);
+
+        expect(err).to.be.an('error');
+        // the destination doc is live and still owns the encrypted refs - they must NOT be released
+        expect(calls.deleteManyAsync.some(c => c.ids && c.ids.includes('enc-id-1'))).to.be.false;
+    });
+
+    it('increments storageUsed by the encrypted-vs-source size delta', async function () {
+        const userId = new ObjectId();
+        const sourceMailboxId = new ObjectId();
+        const targetMailboxId = new ObjectId();
+        const messageId = new ObjectId();
+
+        const sourceMessage = {
+            _id: messageId,
+            mailbox: sourceMailboxId,
+            uid: 1,
+            size: 1000,
+            magic: 'old-magic',
+            unseen: false,
+            flags: [],
+            mimeTree: { header: [], attachmentMap: {} },
+            // Stale plaintext fields from when the source was indexed unencrypted.
+            text: 'plaintext body start',
+            textFooter: 'plaintext spillover that exceeded MAX_PLAINTEXT_INDEXED',
+            html: ['<p>plaintext html</p>'],
+            intro: 'plaintext intro'
+        };
+
+        let cursorIdx = 0;
+        let quotaIncCalls = [];
+        insertedDocs = [];
+
+        let handler = Object.create(MessageHandler.prototype);
+        handler.loggelf = () => {};
+
+        handler.database = {
+            collection: name => {
+                if (name === 'mailboxes') {
+                    return {
+                        findOne: query => {
+                            if (query._id && query._id.equals && query._id.equals(sourceMailboxId)) {
+                                return Promise.resolve({ _id: sourceMailboxId, user: userId, path: 'INBOX', uidValidity: 100 });
+                            }
+                            if (query._id && query._id.equals && query._id.equals(targetMailboxId)) {
+                                return Promise.resolve({
+                                    _id: targetMailboxId,
+                                    user: userId,
+                                    path: 'Vault',
+                                    uidValidity: 200,
+                                    encryptMessages: true
+                                });
+                            }
+                            return Promise.resolve(null);
+                        },
+                        // Returns a uidNext/modifyIndex value for both the source-modseq bump
+                        // before the loop and the target-uidNext bump inside the loop.
+                        findOneAndUpdate: () => Promise.resolve({ value: { uidNext: 1, modifyIndex: 1 } })
+                    };
+                }
+                if (name === 'messages') {
+                    return {
+                        find: () => ({
+                            sort: () => ({
+                                next: () => Promise.resolve(cursorIdx++ === 0 ? sourceMessage : null),
+                                close: () => Promise.resolve()
+                            })
+                        }),
+                        insertOne: doc => {
+                            insertedDocs.push(doc);
+                            return Promise.resolve({ acknowledged: true, insertedId: new ObjectId() });
+                        },
+                        deleteOne: () => Promise.resolve({ deletedCount: 1 })
+                    };
+                }
+                throw new Error('unexpected handler.database.collection: ' + name);
+            }
+        };
+
+        handler.users = {
+            collection: () => ({
+                findOne: () => Promise.resolve({
+                    _id: userId,
+                    encryptMessages: true,
+                    smimeCerts: ['fake-cert']
+                }),
+                findOneAndUpdate: (query, update) => {
+                    if (update && update.$inc && 'storageUsed' in update.$inc) {
+                        quotaIncCalls.push(update.$inc.storageUsed);
+                    }
+                    return Promise.resolve({ value: { storageUsed: 100 } });
+                }
+            })
+        };
+
+        handler.settingsHandler = {
+            get: () => Promise.resolve(100)
+        };
+
+        handler.notifier = {
+            addEntries: (mailbox, entries, cb) => {
+                if (cb) {
+                    return cb();
+                }
+            },
+            fire: () => {}
+        };
+
+        handler.indexer = {
+            getMaildata: () => ({ attachments: [], magic: 'new-magic' })
+        };
+
+        handler.attachmentStorage = {
+            deleteManyAsync: () => Promise.resolve()
+        };
+
+        // Stub the encryption result: encrypted form is 500 bytes larger than source.
+        handler.encryptAndPrepareMessageAsync = () =>
+            Promise.resolve({
+                prepared: {
+                    mimeTree: { header: [], attachmentMap: {} },
+                    size: 1500,
+                    bodystructure: {},
+                    envelope: {},
+                    headers: {}
+                },
+                maildata: { attachments: [], magic: 'new-magic' },
+                type: 'smime'
+            });
+
+        await handler.moveAsync({
+            source: { mailbox: sourceMailboxId },
+            destination: { mailbox: targetMailboxId },
+            messages: [1]
+        });
+
+        // Cleanup block must have called updateQuotaAsync with sizeDelta = 1500 - 1000 = 500
+        expect(quotaIncCalls).to.deep.equal([500]);
+
+        // The moved-and-encrypted document must not carry the source's plaintext-derived fields.
+        expect(insertedDocs).to.have.lengthOf(1);
+        let moved = insertedDocs[0];
+        expect(moved).to.not.have.property('text');
+        expect(moved).to.not.have.property('textFooter');
+        expect(moved).to.not.have.property('html');
+        expect(moved.intro).to.equal('');
+    });
+});

--- a/test/on-copy-uid-shift-test.js
+++ b/test/on-copy-uid-shift-test.js
@@ -1,0 +1,481 @@
+/* eslint no-unused-expressions: 0, prefer-arrow-callback: 0 */
+/* globals before: false, after: false */
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+const { ObjectId } = require('mongodb');
+
+const db = require('../lib/db');
+const onCopy = require('../lib/handlers/on-copy');
+
+describe('on-copy UID arrays', function () {
+    let userId, sourceMailboxId, targetMailboxId;
+    let dbSnapshot;
+    let insertCalls;
+    let nextUid;
+
+    before(function () {
+        userId = new ObjectId();
+        sourceMailboxId = new ObjectId();
+        targetMailboxId = new ObjectId();
+        dbSnapshot = { users: db.users, database: db.database };
+    });
+
+    after(function () {
+        db.users = dbSnapshot.users;
+        db.database = dbSnapshot.database;
+    });
+
+    beforeEach(function () {
+        insertCalls = 0;
+        nextUid = 1;
+
+        let sourceMessages = [
+            { _id: new ObjectId(), mailbox: sourceMailboxId, uid: 10, size: 100, flags: [], mimeTree: { header: [] } },
+            { _id: new ObjectId(), mailbox: sourceMailboxId, uid: 20, size: 200, flags: [], mimeTree: { header: [] } }
+        ];
+        let cursorIdx = 0;
+
+        let mailboxesCollection = {
+            findOne: query => {
+                if (query._id && query._id.equals && query._id.equals(sourceMailboxId)) {
+                    return Promise.resolve({ _id: sourceMailboxId, user: userId, path: 'INBOX' });
+                }
+                if (query.user && query.path === 'Vault') {
+                    return Promise.resolve({ _id: targetMailboxId, user: userId, path: 'Vault', uidValidity: 1000 });
+                }
+                return Promise.resolve(null);
+            },
+            findOneAndUpdate: () => Promise.resolve({ value: { uidNext: nextUid++, modifyIndex: 0 } })
+        };
+
+        let messagesCollection = {
+            find: () => ({
+                sort: () => ({
+                    maxTimeMS: () => ({
+                        next: () => Promise.resolve(sourceMessages[cursorIdx++] || null),
+                        close: () => Promise.resolve()
+                    })
+                })
+            }),
+            updateOne: () => Promise.resolve({ matchedCount: 1, modifiedCount: 1 }),
+            insertOne: () => {
+                insertCalls++;
+                // First insert succeeds, second comes back not acknowledged
+                if (insertCalls === 1) {
+                    return Promise.resolve({ acknowledged: true, insertedId: new ObjectId() });
+                }
+                return Promise.resolve({ acknowledged: false });
+            }
+        };
+
+        let usersCollection = {
+            findOne: () => Promise.resolve({ _id: userId, quota: 0, storageUsed: 0 }),
+            findOneAndUpdate: () => Promise.resolve({ value: { storageUsed: 100 } })
+        };
+
+        db.database = {
+            collection: name => {
+                if (name === 'mailboxes') return mailboxesCollection;
+                if (name === 'messages') return messagesCollection;
+                throw new Error('unexpected db.database.collection: ' + name);
+            }
+        };
+        db.users = {
+            collection: name => {
+                if (name === 'users') return usersCollection;
+                throw new Error('unexpected db.users.collection: ' + name);
+            }
+        };
+    });
+
+    it('clears plaintext index fields when copying into an encrypted mailbox', async function () {
+        let sourceMessages = [
+            {
+                _id: new ObjectId(),
+                mailbox: sourceMailboxId,
+                uid: 10,
+                size: 100,
+                flags: [],
+                mimeTree: { header: [], attachmentMap: {} },
+                // Stale plaintext fields from when the source was indexed unencrypted.
+                text: 'plaintext body start',
+                textFooter: 'plaintext spillover that exceeded MAX_PLAINTEXT_INDEXED',
+                html: ['<p>plaintext html</p>'],
+                intro: 'plaintext intro'
+            }
+        ];
+        let cursorIdx = 0;
+        let insertedDoc = null;
+
+        db.database = {
+            collection: name => {
+                if (name === 'mailboxes') {
+                    return {
+                        findOne: query => {
+                            if (query._id && query._id.equals && query._id.equals(sourceMailboxId)) {
+                                return Promise.resolve({ _id: sourceMailboxId, user: userId, path: 'INBOX' });
+                            }
+                            if (query.user && query.path === 'Vault') {
+                                return Promise.resolve({
+                                    _id: targetMailboxId,
+                                    user: userId,
+                                    path: 'Vault',
+                                    uidValidity: 1000,
+                                    encryptMessages: true
+                                });
+                            }
+                            return Promise.resolve(null);
+                        },
+                        findOneAndUpdate: () => Promise.resolve({ value: { uidNext: 1, modifyIndex: 0 } })
+                    };
+                }
+                if (name === 'messages') {
+                    return {
+                        find: () => ({
+                            sort: () => ({
+                                maxTimeMS: () => ({
+                                    next: () => Promise.resolve(sourceMessages[cursorIdx++] || null),
+                                    close: () => Promise.resolve()
+                                })
+                            })
+                        }),
+                        updateOne: () => Promise.resolve({ matchedCount: 1, modifiedCount: 1 }),
+                        insertOne: doc => {
+                            insertedDoc = doc;
+                            return Promise.resolve({ acknowledged: true, insertedId: new ObjectId() });
+                        }
+                    };
+                }
+                throw new Error('unexpected db.database.collection: ' + name);
+            }
+        };
+        db.users = {
+            collection: () => ({
+                findOne: () => Promise.resolve({ _id: userId, quota: 0, storageUsed: 0, smimeCerts: ['fake-cert-pem'] }),
+                findOneAndUpdate: () => Promise.resolve({ value: { storageUsed: 100 } })
+            })
+        };
+
+        let server = {
+            logger: { debug() {}, error() {} },
+            loggelf() {},
+            notifier: {
+                addEntries(target, entry, cb) {
+                    if (cb) {
+                        return cb();
+                    }
+                },
+                fire() {}
+            }
+        };
+
+        let messageHandler = {
+            isMessageEncrypted: () => false,
+            _getContentType: () => '',
+            attachmentStorage: { updateMany: () => Promise.resolve() },
+            // Stub returns a fresh prepared/maildata so the copy handler treats this as a successful encrypt.
+            encryptAndPrepareMessageAsync: () =>
+                Promise.resolve({
+                    prepared: {
+                        mimeTree: { header: [], attachmentMap: {} },
+                        size: 500,
+                        bodystructure: {},
+                        envelope: {},
+                        headers: {}
+                    },
+                    maildata: { attachments: [], magic: 'new-magic' },
+                    type: 'smime'
+                })
+        };
+
+        let connection = { send() {} };
+        let session = {
+            id: 'test-session',
+            user: { id: userId, address: 'test@example.com' },
+            socket: { destroyed: false, readyState: 'open' }
+        };
+
+        let handler = onCopy(server, messageHandler);
+
+        let { status } = await new Promise((resolve, reject) => {
+            handler(connection, sourceMailboxId, { messages: [10], destination: 'Vault' }, session, (err, s, i) => {
+                if (err) return reject(err);
+                resolve({ status: s, info: i });
+            });
+        });
+
+        expect(status).to.be.true;
+        expect(insertedDoc).to.not.be.null;
+        // Stored encrypted-copy document must not carry the source's plaintext-derived fields.
+        expect(insertedDoc).to.not.have.property('text');
+        expect(insertedDoc).to.not.have.property('textFooter');
+        expect(insertedDoc).to.not.have.property('html');
+        expect(insertedDoc.intro).to.equal('');
+    });
+
+    // Build a self-contained COPY environment with spies on the attachment-storage refcount calls.
+    function setupCopyEnv({ sourceMessages, targetEncrypted = false, encryptResult = null, insertOneImpl, updateManyImpl, deleteManyAsyncImpl }) {
+        let cursorIdx = 0;
+        let calls = { insertOne: [], updateOneCopied: [], updateMany: [], deleteManyAsync: [] };
+
+        let mailboxesCollection = {
+            findOne: query => {
+                if (query._id && query._id.equals && query._id.equals(sourceMailboxId)) {
+                    return Promise.resolve({ _id: sourceMailboxId, user: userId, path: 'INBOX' });
+                }
+                if (query.user && query.path === 'Vault') {
+                    return Promise.resolve({ _id: targetMailboxId, user: userId, path: 'Vault', uidValidity: 1000, encryptMessages: !!targetEncrypted });
+                }
+                return Promise.resolve(null);
+            },
+            findOneAndUpdate: () => Promise.resolve({ value: { uidNext: nextUid++, modifyIndex: 0 } })
+        };
+
+        let messagesCollection = {
+            find: () => ({
+                sort: () => ({
+                    maxTimeMS: () => ({
+                        next: () => Promise.resolve(sourceMessages[cursorIdx++] || null),
+                        close: () => Promise.resolve()
+                    })
+                })
+            }),
+            updateOne: (query, update) => {
+                if (update && update.$set && update.$set.copied) {
+                    calls.updateOneCopied.push(query);
+                }
+                return Promise.resolve({ matchedCount: 1, modifiedCount: 1 });
+            },
+            insertOne: doc => {
+                calls.insertOne.push(doc);
+                return insertOneImpl(doc, calls.insertOne.length);
+            }
+        };
+
+        let usersCollection = {
+            findOne: () => Promise.resolve({ _id: userId, quota: 0, storageUsed: 0, smimeCerts: ['fake-cert-pem'] }),
+            findOneAndUpdate: () => Promise.resolve({ value: { storageUsed: 100 } })
+        };
+
+        db.database = {
+            collection: name => {
+                if (name === 'mailboxes') return mailboxesCollection;
+                if (name === 'messages') return messagesCollection;
+                throw new Error('unexpected db.database.collection: ' + name);
+            }
+        };
+        db.users = {
+            collection: name => {
+                if (name === 'users') return usersCollection;
+                throw new Error('unexpected db.users.collection: ' + name);
+            }
+        };
+
+        let server = {
+            logger: { debug() {}, error() {} },
+            loggelf() {},
+            notifier: {
+                addEntries(target, entry, cb) {
+                    if (cb) {
+                        return cb();
+                    }
+                },
+                fire() {}
+            }
+        };
+
+        let messageHandler = {
+            isMessageEncrypted: () => false,
+            _getContentType: () => '',
+            encryptAndPrepareMessageAsync: () => Promise.resolve(encryptResult),
+            attachmentStorage: {
+                updateMany: (ids, count, magic) => {
+                    calls.updateMany.push({ ids, count, magic });
+                    return updateManyImpl ? updateManyImpl(ids, count, magic) : Promise.resolve();
+                },
+                deleteManyAsync: (ids, magic) => {
+                    calls.deleteManyAsync.push({ ids, magic });
+                    return deleteManyAsyncImpl ? deleteManyAsyncImpl(ids, magic) : Promise.resolve();
+                }
+            }
+        };
+
+        return { server, messageHandler, calls };
+    }
+
+    function runCopy(server, messageHandler, messages) {
+        let connection = { send() {} };
+        let session = {
+            id: 'test-session',
+            user: { id: userId, address: 'test@example.com' },
+            socket: { destroyed: false, readyState: 'open' }
+        };
+        let handler = onCopy(server, messageHandler);
+        return new Promise((resolve, reject) => {
+            handler(connection, sourceMailboxId, { messages, destination: 'Vault' }, session, (err, s, i) => {
+                if (err) return reject(err);
+                resolve({ status: s, info: i });
+            });
+        });
+    }
+
+    let encryptResult = {
+        prepared: {
+            mimeTree: { header: [], attachmentMap: { '1': 'enc-id-1' } },
+            size: 500,
+            bodystructure: {},
+            envelope: {},
+            headers: {}
+        },
+        maildata: { attachments: [], magic: 'new-magic' },
+        type: 'smime'
+    };
+
+    it('releases newly encrypted attachments when the encrypted-copy insert is not acknowledged', async function () {
+        let { server, messageHandler, calls } = setupCopyEnv({
+            sourceMessages: [{ _id: new ObjectId(), mailbox: sourceMailboxId, uid: 10, size: 100, flags: [], magic: 'src-magic', mimeTree: { header: [], attachmentMap: { '1': 'src-id-1' } } }],
+            targetEncrypted: true,
+            encryptResult,
+            insertOneImpl: () => Promise.resolve({ acknowledged: false })
+        });
+
+        let { status, info } = await runCopy(server, messageHandler, [10]);
+
+        expect(status).to.be.true;
+        // failed insert is dropped from the result
+        expect(info.sourceUid).to.deep.equal([]);
+        // encrypted bodies created by storeNodeBodies() must be released with the NEW magic
+        expect(calls.deleteManyAsync).to.have.lengthOf(1);
+        expect(calls.deleteManyAsync[0].ids).to.deep.equal(['enc-id-1']);
+        expect(calls.deleteManyAsync[0].magic).to.equal('new-magic');
+        // encrypted path never bumps refcount via updateMany, and a failed copy must not mark the source
+        expect(calls.updateMany).to.have.lengthOf(0);
+        expect(calls.updateOneCopied).to.have.lengthOf(0);
+    });
+
+    it('releases newly encrypted attachments and propagates when the encrypted-copy insert throws', async function () {
+        let { server, messageHandler, calls } = setupCopyEnv({
+            sourceMessages: [{ _id: new ObjectId(), mailbox: sourceMailboxId, uid: 10, size: 100, flags: [], magic: 'src-magic', mimeTree: { header: [], attachmentMap: { '1': 'src-id-1' } } }],
+            targetEncrypted: true,
+            encryptResult,
+            insertOneImpl: () => Promise.reject(Object.assign(new Error('insert boom'), { code: 'StoreError' }))
+        });
+
+        let err;
+        try {
+            await runCopy(server, messageHandler, [10]);
+        } catch (e) {
+            err = e;
+        }
+
+        expect(err).to.be.an('error');
+        expect(calls.deleteManyAsync).to.have.lengthOf(1);
+        expect(calls.deleteManyAsync[0].ids).to.deep.equal(['enc-id-1']);
+        expect(calls.deleteManyAsync[0].magic).to.equal('new-magic');
+        expect(calls.updateOneCopied).to.have.lengthOf(0);
+    });
+
+    it('increments plaintext refcount before insert and releases it when the insert is not acknowledged', async function () {
+        let { server, messageHandler, calls } = setupCopyEnv({
+            sourceMessages: [{ _id: new ObjectId(), mailbox: sourceMailboxId, uid: 10, size: 100, flags: [], magic: 'src-magic', mimeTree: { header: [], attachmentMap: { '1': 'src-id-1' } } }],
+            targetEncrypted: false,
+            insertOneImpl: () => Promise.resolve({ acknowledged: false })
+        });
+
+        let { status } = await runCopy(server, messageHandler, [10]);
+
+        expect(status).to.be.true;
+        // +1 established before the insert
+        expect(calls.updateMany).to.have.lengthOf(1);
+        expect(calls.updateMany[0].ids).to.deep.equal(['src-id-1']);
+        expect(calls.updateMany[0].count).to.equal(1);
+        expect(calls.updateMany[0].magic).to.equal('src-magic');
+        // and released after the insert failed
+        expect(calls.deleteManyAsync).to.have.lengthOf(1);
+        expect(calls.deleteManyAsync[0].ids).to.deep.equal(['src-id-1']);
+        expect(calls.deleteManyAsync[0].magic).to.equal('src-magic');
+        expect(calls.updateOneCopied).to.have.lengthOf(0);
+    });
+
+    it('skips the message without inserting when the plaintext refcount increment fails', async function () {
+        let { server, messageHandler, calls } = setupCopyEnv({
+            sourceMessages: [{ _id: new ObjectId(), mailbox: sourceMailboxId, uid: 10, size: 100, flags: [], magic: 'src-magic', mimeTree: { header: [], attachmentMap: { '1': 'src-id-1' } } }],
+            targetEncrypted: false,
+            insertOneImpl: () => Promise.resolve({ acknowledged: true, insertedId: new ObjectId() }),
+            updateManyImpl: () => Promise.reject(Object.assign(new Error('refcount boom'), { code: 'AttachmentUpdateError' }))
+        });
+
+        let { status, info } = await runCopy(server, messageHandler, [10]);
+
+        expect(status).to.be.true;
+        // no under-counted copy is stored
+        expect(calls.insertOne).to.have.lengthOf(0);
+        expect(info.sourceUid).to.deep.equal([]);
+        // nothing to release because the increment never took effect
+        expect(calls.deleteManyAsync).to.have.lengthOf(0);
+        expect(calls.updateOneCopied).to.have.lengthOf(0);
+    });
+
+    it('marks the source copied only after a confirmed insert', async function () {
+        let { server, messageHandler, calls } = setupCopyEnv({
+            sourceMessages: [
+                { _id: new ObjectId(), mailbox: sourceMailboxId, uid: 10, size: 100, flags: [], magic: 'src-magic', mimeTree: { header: [], attachmentMap: {} } },
+                { _id: new ObjectId(), mailbox: sourceMailboxId, uid: 20, size: 200, flags: [], magic: 'src-magic', mimeTree: { header: [], attachmentMap: {} } }
+            ],
+            targetEncrypted: false,
+            // first insert succeeds, second is not acknowledged
+            insertOneImpl: (doc, n) => (n === 1 ? Promise.resolve({ acknowledged: true, insertedId: new ObjectId() }) : Promise.resolve({ acknowledged: false }))
+        });
+
+        let { status, info } = await runCopy(server, messageHandler, [10, 20]);
+
+        expect(status).to.be.true;
+        expect(info.sourceUid).to.deep.equal([10]);
+        // copied:true is issued exactly once - for the message whose insert was acknowledged
+        expect(calls.updateOneCopied).to.have.lengthOf(1);
+    });
+
+    it('omits failed insertOne UIDs from sourceUid/destinationUid', async function () {
+        let server = {
+            logger: { debug() {}, error() {} },
+            loggelf() {},
+            notifier: {
+                addEntries(target, entry, cb) {
+                    if (cb) {
+                        return cb();
+                    }
+                },
+                fire() {}
+            }
+        };
+
+        let messageHandler = {
+            isMessageEncrypted: () => false,
+            _getContentType: () => '',
+            attachmentStorage: { updateMany: () => Promise.resolve() }
+        };
+
+        let connection = { send() {} };
+        let session = {
+            id: 'test-session',
+            user: { id: userId, address: 'test@example.com' },
+            socket: { destroyed: false, readyState: 'open' }
+        };
+
+        let handler = onCopy(server, messageHandler);
+
+        let { status, info } = await new Promise((resolve, reject) => {
+            handler(connection, sourceMailboxId, { messages: [10, 20], destination: 'Vault' }, session, (err, s, i) => {
+                if (err) return reject(err);
+                resolve({ status: s, info: i });
+            });
+        });
+
+        expect(insertCalls).to.equal(2);
+        expect(status).to.be.true;
+        expect(info.sourceUid).to.deep.equal([10]);
+        expect(info.destinationUid).to.have.lengthOf(1);
+    });
+});


### PR DESCRIPTION
* Improved quota accounting for encrypted mail (both S/MIME and PGP) (+ test)
* Fixed partial copy UID shift and response (+ test)
* Fixed encryption not clearing existing plaintext footer (+ test)
* Fixed IMAP sessions not being notified on copy