### PR TITLE
ZMS-76: Harden release and docker workflows

### DIFF
--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -9,6 +9,9 @@ on:
         branches:
             - master
 
+# Default to read-only permissions
+permissions: read-all
+
 jobs:
     check_commit:
         runs-on: ubuntu-latest
@@ -16,7 +19,7 @@ jobs:
             should_run: ${{ steps.check_commit_message.outputs.should_run }}
         steps:
             - name: Checkout code
-              uses: actions/checkout@v6
+              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v6
               with:
                   fetch-depth: 2
 
@@ -36,23 +39,28 @@ jobs:
         needs: check_commit
         if: ${{ needs.check_commit.outputs.should_run == 'true' }}
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+            attestations: write
+            id-token: write
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v6
 
             - name: Set up QEMU
-              uses: docker/setup-qemu-action@v3
+              uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
               with:
                   platforms: 'arm64'
 
             - name: Set up Docker Buildx
               id: buildx
-              uses: docker/setup-buildx-action@v3
+              uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
               with:
                   platforms: linux/arm64,linux/amd64
 
             - name: Login to GHCR
-              uses: docker/login-action@v3
+              uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
               with:
                   registry: ${{ env.REGISTRY }}
                   username: ${{ github.repository_owner }}
@@ -60,7 +68,7 @@ jobs:
 
             - name: Extract metadata (tags, labels) for Docker
               id: meta
-              uses: docker/metadata-action@v5
+              uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
               with:
                   images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
                   flavor: |
@@ -69,7 +77,7 @@ jobs:
                       type=raw,value=latest
 
             - name: Build and push Docker image
-              uses: docker/build-push-action@v6
+              uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
               id: push
               with:
                   context: .
@@ -77,3 +85,10 @@ jobs:
                   platforms: ${{ steps.buildx.outputs.platforms }}
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
+
+            - name: Generate artifact attestation
+              uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+              with:
+                  subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+                  subject-digest: ${{ steps.push.outputs.digest }}
+                  push-to-registry: true

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -19,7 +19,7 @@ jobs:
             should_run: ${{ steps.check_commit_message.outputs.should_run }}
         steps:
             - name: Checkout code
-              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
               with:
                   fetch-depth: 2
 
@@ -46,7 +46,7 @@ jobs:
             id-token: write
         steps:
             - name: Checkout
-              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
             - name: Set up QEMU
               uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,9 @@ on:
         branches:
             - master
 
+# Default to read-only permissions
+permissions: read-all
+
 env:
     REGISTRY: ghcr.io
     IMAGE_NAME: ${{ github.repository }}
@@ -16,7 +19,6 @@ jobs:
             contents: write
             pull-requests: write
             id-token: write
-
         runs-on: ubuntu-latest
         outputs:
             major: ${{ steps.release.outputs.major }}
@@ -24,7 +26,7 @@ jobs:
             patch: ${{ steps.release.outputs.patch }}
             release_created: ${{ steps.release.outputs.release_created }}
         steps:
-            - uses: googleapis/release-please-action@v4
+            - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
               id: release
 
     publish_npm:
@@ -36,8 +38,8 @@ jobs:
             contents: read
             id-token: write
         steps:
-            - uses: actions/checkout@v6
-            - uses: actions/setup-node@v6
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+            - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
               with:
                   node-version: 24
                   registry-url: 'https://registry.npmjs.org'
@@ -48,35 +50,32 @@ jobs:
         timeout-minutes: 30
         name: Create and publish a Docker image
         runs-on: ubuntu-latest
-
         permissions:
             contents: read
             packages: write
             attestations: write
             id-token: write
-
         needs: release_please
-        if: ${{needs.release_please.outputs.release_created}}
-
+        if: ${{ needs.release_please.outputs.release_created }}
         steps:
-            - run: echo version v${{needs.release_please.outputs.major}}.${{needs.release_please.outputs.minor}}.${{needs.release_please.outputs.patch}}
+            - run: echo "Building version v${{needs.release_please.outputs.major}}.${{needs.release_please.outputs.minor}}.${{needs.release_please.outputs.patch}}"
 
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v6
 
             - name: Set up QEMU
-              uses: docker/setup-qemu-action@v3
+              uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
               with:
                   platforms: 'arm64'
 
             - name: Set up Docker Buildx
               id: buildx
-              uses: docker/setup-buildx-action@v3
+              uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
               with:
                   platforms: linux/arm64,linux/amd64
 
             - name: Log in to the Container registry
-              uses: docker/login-action@v3
+              uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
               with:
                   registry: ${{ env.REGISTRY }}
                   username: ${{ github.repository_owner }}
@@ -84,7 +83,7 @@ jobs:
 
             - name: Extract metadata (tags, labels) for Docker
               id: meta
-              uses: docker/metadata-action@v5
+              uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
               with:
                   images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
                   flavor: |
@@ -96,7 +95,7 @@ jobs:
 
             - name: Build and push Docker image
               id: push
-              uses: docker/build-push-action@v6
+              uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
               with:
                   context: .
                   push: true
@@ -105,27 +104,29 @@ jobs:
                   labels: ${{ steps.meta.outputs.labels }}
 
             - name: Generate artifact attestation
-              uses: actions/attest-build-provenance@v3
+              uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
               with:
-                  subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+                  subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
                   subject-digest: ${{ steps.push.outputs.digest }}
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  push-to-registry: true
 
     publish_artifacts:
         timeout-minutes: 30
         name: Package and upload release artifacts
         runs-on: ubuntu-latest
         needs: release_please
-        if: ${{needs.release_please.outputs.release_created}}
+        if: ${{ needs.release_please.outputs.release_created }}
         permissions:
             contents: write
+            attestations: write
+            id-token: write
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
             - name: Setup Node
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4
               with:
                   node-version: 24
 
@@ -137,25 +138,62 @@ jobs:
                   mkdir -p ${{ runner.temp }}/release_build
                   cp -R . ${{ runner.temp }}/release_build/
 
+            - name: Set archive names
+              id: names
+              run: |
+                  echo "zip=${{env.PACKAGE_NAME}}-${{needs.release_please.outputs.major}}.${{needs.release_please.outputs.minor}}.${{needs.release_please.outputs.patch}}.zip" >> $GITHUB_OUTPUT
+                  echo "tar=${{env.PACKAGE_NAME}}-${{needs.release_please.outputs.major}}.${{needs.release_please.outputs.minor}}.${{needs.release_please.outputs.patch}}.tar.gz" >> $GITHUB_OUTPUT
+                  echo "zip_checksum=${{env.PACKAGE_NAME}}-${{needs.release_please.outputs.major}}.${{needs.release_please.outputs.minor}}.${{needs.release_please.outputs.patch}}.zip.sha256" >> $GITHUB_OUTPUT
+                  echo "tar_checksum=${{env.PACKAGE_NAME}}-${{needs.release_please.outputs.major}}.${{needs.release_please.outputs.minor}}.${{needs.release_please.outputs.patch}}.tar.gz.sha256" >> $GITHUB_OUTPUT
+
             - name: Create zip archive
               run: |
-                  # Create a zip archive excluding .git directory
                   ROOT_DIR=$(pwd)
                   cd ${{ runner.temp }}/release_build
-                  zip -r $ROOT_DIR/${{env.PACKAGE_NAME}}-${{needs.release_please.outputs.major}}.${{needs.release_please.outputs.minor}}.${{needs.release_please.outputs.patch}}.zip . -x "*.git" "*.git/*"
+                  zip -r $ROOT_DIR/${{ steps.names.outputs.zip }} . -x "*.git" "*.git/*"
                   cd $ROOT_DIR
 
             - name: Create tar.gz archive
               run: |
-                  # Create a tar.gz archive excluding .git directory
-                  tar --exclude='.git' --exclude='.git/*' -czf ${{env.PACKAGE_NAME}}-${{needs.release_please.outputs.major}}.${{needs.release_please.outputs.minor}}.${{needs.release_please.outputs.patch}}.tar.gz -C ${{ runner.temp }}/release_build/ .
+                  tar --exclude='.git' --exclude='.git/*' \
+                    -czf ${{ steps.names.outputs.tar }} \
+                    -C ${{ runner.temp }}/release_build/ .
+
+            - name: Generate SHA-256 checksums
+              run: |
+                  sha256sum ${{ steps.names.outputs.zip }} > ${{ steps.names.outputs.zip_checksum }}
+                  sha256sum ${{ steps.names.outputs.tar }} > ${{ steps.names.outputs.tar_checksum }}
+                  cat ${{ steps.names.outputs.zip_checksum }}
+                  cat ${{ steps.names.outputs.tar_checksum }}
+
+            - name: Attest zip archive
+              uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+              with:
+                  subject-path: ${{ steps.names.outputs.zip }}
+
+            - name: Attest tar.gz archive
+              uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+              with:
+                  subject-path: ${{ steps.names.outputs.tar }}
+
+            - name: Attest zip checksum
+              uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+              with:
+                  subject-path: ${{ steps.names.outputs.zip_checksum }}
+
+            - name: Attest tar.gz checksum
+              uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+              with:
+                  subject-path: ${{ steps.names.outputs.tar_checksum }}
 
             - name: Upload artifacts to release
-              uses: softprops/action-gh-release@v2
+              uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
               with:
                   files: |
-                      ${{env.PACKAGE_NAME}}-${{needs.release_please.outputs.major}}.${{needs.release_please.outputs.minor}}.${{needs.release_please.outputs.patch}}.zip
-                      ${{env.PACKAGE_NAME}}-${{needs.release_please.outputs.major}}.${{needs.release_please.outputs.minor}}.${{needs.release_please.outputs.patch}}.tar.gz
+                      ${{ steps.names.outputs.zip }}
+                      ${{ steps.names.outputs.tar }}
+                      ${{ steps.names.outputs.zip_checksum }}
+                      ${{ steps.names.outputs.tar_checksum }}
                   tag_name: v${{needs.release_please.outputs.major}}.${{needs.release_please.outputs.minor}}.${{needs.release_please.outputs.patch}}
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Attestate all generated artifacts
- Generate separare sha256 checksums for zip files generated for a release
- attestate sha256 checksum files too
- harden permissions
- pin versions to commit hashes