### PR TITLE
ZMS-70: Change auth ratelimit order

### DIFF
--- a/lib/user-handler.js
+++ b/lib/user-handler.js
@@ -635,6 +635,7 @@ class UserHandler {
 
         let appPassword;
         let appPasswordError;
+        let appPasswordScopeMismatch;
         let appPasswordFailure = 'Invalid Auth - Master password did not match';
 
         if (requiredScope !== 'master') {
@@ -685,6 +686,12 @@ class UserHandler {
                     }
 
                     if (!asp.scopes.includes('*') && !asp.scopes.includes(requiredScope)) {
+                        appPasswordScopeMismatch = asp;
+                        meta.asp = asp._id;
+                        meta.aname = asp.description;
+                        passwordType = 'asp';
+                        passwordId = asp._id.toString();
+
                         let err = new Error('Authentication failed. Invalid scope');
                         err.responseCode = 403;
                         err.code = 'InvalidAuthScope';
@@ -955,6 +962,14 @@ class UserHandler {
                 return await authSuccess(authResponse);
             }
 
+            if (appPasswordScopeMismatch) {
+                // The same value may also be the master password, which takes precedence if it matches.
+                delete meta.asp;
+                delete meta.aname;
+                passwordType = 'master';
+                passwordId = undefined;
+            }
+
             let enabled2fa = tools.getEnabled2fa(userData.enabled2fa);
             let requirePasswordChange = false;
             let usingTemporaryPassword = false;
@@ -1114,6 +1129,10 @@ class UserHandler {
                 if (appPasswordError.code === 'InvalidAuthScope') {
                     meta.result = 'fail';
                     meta.source = 'asp';
+                    meta.asp = appPasswordScopeMismatch._id;
+                    meta.aname = appPasswordScopeMismatch.description;
+                    passwordType = 'asp';
+                    passwordId = appPasswordScopeMismatch._id.toString();
                     await this.logAuthEvent(userData._id, meta);
                 }
                 throw appPasswordError;

--- a/lib/user-handler.js
+++ b/lib/user-handler.js
@@ -460,7 +460,7 @@ class UserHandler {
 
         let now = new Date();
 
-        let passwordType = 'master'; // try 'master' first and 'asp' later
+        let passwordType = 'master';
         let passwordId;
 
         meta = meta || {};
@@ -633,45 +633,117 @@ class UserHandler {
         // make sure we use the primary domain if available
         userDomain = (userData.address || '').split('@').pop() || userDomain;
 
-        try {
-            // check if there are not too many auth attempts for that user
-            rateLimitRes = await this.rateLimitUser(userData._id, meta, 0);
-        } catch (err) {
-            err.responseCode = 500;
-            err.code = 'InternalDatabaseError';
-            err.user = userData._id;
-            this.loggelf({
-                short_message: '[AUTHFAIL] ' + username,
-                _error: err.message,
-                _code: err.code,
-                _auth_result: 'error',
-                _username: username,
-                _domain: userDomain,
-                _user: userData._id,
-                _scope: requiredScope,
-                _ip: meta.ip,
-                _sess: meta.sess
-            });
-            throw err;
+        let appPassword;
+        let appPasswordError;
+        let appPasswordFailure = 'Invalid Auth - Master password did not match';
+
+        if (requiredScope !== 'master') {
+            let normalizedPassword = password.replace(/\s+/g, '').toLowerCase();
+
+            if (!/^[a-z]{16}$/.test(normalizedPassword)) {
+                appPasswordFailure = 'Invalid Auth - Password does not match master password and is not a valid application-specific password';
+            } else {
+                let selector = getStringSelector(normalizedPassword);
+                let asps;
+
+                try {
+                    asps = await this.users
+                        .collection('asps')
+                        .find({
+                            user: userData._id
+                        })
+                        .maxTimeMS(consts.DB_MAX_TIME_USERS)
+                        .toArray();
+                } catch (err) {
+                    err.responseCode = 500;
+                    err.code = 'InternalDatabaseError';
+                    appPasswordError = err;
+                }
+
+                if (!appPasswordError && (!asps || !asps.length)) {
+                    appPasswordFailure = 'Invalid Auth - User does not have application-specific passwords configured';
+                }
+
+                for (let asp of asps || []) {
+                    if (asp.selector && asp.selector !== selector) {
+                        // no need to check, definitely a wrong one
+                        continue;
+                    }
+
+                    let success;
+                    try {
+                        success = await hashes.compare(normalizedPassword, asp.password);
+                    } catch (err) {
+                        err.responseCode = 500;
+                        err.code = 'HashError';
+                        appPasswordError = err;
+                        break;
+                    }
+
+                    if (!success) {
+                        continue;
+                    }
+
+                    if (!asp.scopes.includes('*') && !asp.scopes.includes(requiredScope)) {
+                        let err = new Error('Authentication failed. Invalid scope');
+                        err.responseCode = 403;
+                        err.code = 'InvalidAuthScope';
+                        err.response = 'NO'; // imap response code
+                        appPasswordError = err;
+                        break;
+                    }
+
+                    appPassword = asp;
+                    break;
+                }
+
+                if (!appPassword && !appPasswordError && asps && asps.length) {
+                    appPasswordFailure = 'Invalid Auth - Application-specific password did not match';
+                }
+            }
         }
 
-        if (!rateLimitRes.success) {
-            // too many failed attempts for this user
-            this.loggelf({
-                short_message: '[AUTHFAIL] ' + username,
-                _error: 'Rate limited',
-                _auth_result: 'ratelimited',
-                _username: username,
-                _domain: userDomain,
-                _user: userData._id,
-                _scope: requiredScope,
-                _ip: meta.ip,
-                _sess: meta.sess
-            });
+        if (!appPassword) {
+            try {
+                // check if there are not too many master password attempts for that user
+                rateLimitRes = await this.rateLimitUser(userData._id, meta, 0);
+            } catch (err) {
+                err.responseCode = 500;
+                err.code = 'InternalDatabaseError';
+                err.user = userData._id;
+                this.loggelf({
+                    short_message: '[AUTHFAIL] ' + username,
+                    _error: err.message,
+                    _code: err.code,
+                    _auth_result: 'error',
+                    _username: username,
+                    _domain: userDomain,
+                    _user: userData._id,
+                    _scope: requiredScope,
+                    _ip: meta.ip,
+                    _sess: meta.sess
+                });
+                throw err;
+            }
 
-            let err = rateLimitResponse(rateLimitRes);
-            err.user = userData._id;
-            throw err;
+            if (!rateLimitRes.success) {
+                // too many failed master password attempts for this user
+                this.loggelf({
+                    short_message: '[AUTHFAIL] ' + username,
+                    _error: 'Rate limited',
+                    _auth_result: 'ratelimited',
+                    _username: username,
+                    _domain: userDomain,
+                    _user: userData._id,
+                    _scope: requiredScope,
+                    _ip: meta.ip,
+                    _sess: meta.sess
+                });
+
+                let err = rateLimitResponse(rateLimitRes);
+                err.user = userData._id;
+                throw err;
+            }
         }
 
         if (userData.disabled) {
@@ -739,6 +811,7 @@ class UserHandler {
                 let isPasswordPwned = !!userData.passwordPwned;
                 const twoWeeksMS = 14 * 24 * 60 * 60 * 1000;
                 if (
+                    passwordType === 'master' &&
                     config.pwned &&
                     config.pwned.enabled &&
                     config.pwned.type &&
@@ -792,11 +865,13 @@ class UserHandler {
                     }
                 }
 
-                // clear rate limit counter on success
-                try {
-                    await this.rateLimitReleaseUser(userData._id);
-                } catch {
-                    //ignore
+                if (passwordType === 'master') {
+                    // a successful master password resets failed master password attempts
+                    try {
+                        await this.rateLimitReleaseUser(userData._id);
+                    } catch {
+                        //ignore
+                    }
                 }
 
                 const log = {
@@ -824,6 +899,61 @@ class UserHandler {
 
                 return [authResponse, userData._id];
             };
+
+            if (appPassword) {
+                meta.source = 'asp';
+                meta.asp = appPassword._id;
+                // store ASP name in case the ASP gets deleted and for faster listing
+                meta.aname = appPassword.description;
+
+                passwordType = 'asp';
+                passwordId = appPassword._id.toString();
+                meta.result = 'success';
+
+                let authEvent;
+                try {
+                    authEvent = await this.logAuthEvent(userData._id, meta);
+                } catch (err) {
+                    // don't really care
+                }
+
+                let aspUpdates = {
+                    used: now,
+                    authEvent,
+                    authIp: meta.ip
+                };
+
+                if (appPassword.ttl) {
+                    // extend temporary password ttl every time it is used
+                    aspUpdates.expires = new Date(now.getTime() + appPassword.ttl * 1000);
+                }
+
+                try {
+                    await this.users.collection('asps').updateOne(
+                        {
+                            _id: appPassword._id
+                        },
+                        {
+                            $set: aspUpdates
+                        },
+                        {
+                            maxTimeMS: consts.DB_MAX_TIME_USERS
+                        }
+                    );
+                } catch (err) {
+                    // ignore
+                }
+
+                const authResponse = {
+                    user: userData._id,
+                    username: userData.username,
+                    scope: requiredScope,
+                    asp: appPassword._id.toString(),
+                    require2fa: false // application scope never requires 2FA
+                };
+
+                return await authSuccess(authResponse);
+            }
 
             let enabled2fa = tools.getEnabled2fa(userData.enabled2fa);
             let requirePasswordChange = false;
@@ -980,159 +1110,20 @@ class UserHandler {
                 return await authSuccess(authResponse);
             }
 
-            if (requiredScope === 'master') {
-                // only master password can be used for management tasks
-                meta.result = 'fail';
-                meta.source = 'master';
-                await this.logAuthEvent(userData._id, meta);
-
-                let err = new Error('Invalid Auth - Master password did not match');
-                err.responseCode = 403;
-                err.code = 'AuthFail'; // will be returned as failed auth, not an error
-                throw err;
-            }
-
-            // try application specific passwords
-            password = password.replace(/\s+/g, '').toLowerCase();
-
-            if (!/^[a-z]{16}$/.test(password)) {
-                // does not look like an application specific password
-                meta.result = 'fail';
-                meta.source = 'master';
-                await this.logAuthEvent(userData._id, meta);
-
-                let err = new Error('Invalid Auth - Password does not match master password and is not a valid application-specific password');
-                err.responseCode = 403;
-                err.code = 'AuthFail'; // will be returned as failed auth, not an error
-                throw err;
-            }
-
-            let selector = getStringSelector(password);
-
-            let asps;
-            try {
-                asps = await this.users
-                    .collection('asps')
-                    .find({
-                        user: userData._id
-                    })
-                    .maxTimeMS(consts.DB_MAX_TIME_USERS)
-                    .toArray();
-            } catch (err) {
-                err.responseCode = 500;
-                err.code = 'InternalDatabaseError';
-                throw err;
-            }
-
-            if (!asps || !asps.length) {
-                // user does not have app specific passwords set
-                meta.result = 'fail';
-                meta.source = 'master';
-                await this.logAuthEvent(userData._id, meta);
-
-                let err = new Error('Invalid Auth - User does not have application-specific passwords configured');
-                err.responseCode = 403;
-                err.code = 'AuthFail'; // will be returned as failed auth, not an error
-                throw err;
-            }
-
-            for (let asp of asps) {
-                if (asp.selector && asp.selector !== selector) {
-                    // no need to check, definitely a wrong one
-                    continue;
-                }
-
-                let success;
-                try {
-                    success = await hashes.compare(password, asp.password);
-                } catch (err) {
-                    err.responseCode = 500;
-                    err.code = 'HashError';
-                    throw err;
-                }
-
-                if (!success) {
-                    continue;
-                }
-
-                // Found a matching Application Specific Password
-
-                meta.source = 'asp';
-                meta.asp = asp._id;
-                // store ASP name in case the ASP gets deleted and for faster listing
-                meta.aname = asp.description;
-
-                passwordType = 'asp';
-                passwordId = asp._id.toString();
-
-                // Check if passwords scope matches required scope
-                if (!asp.scopes.includes('*') && !asp.scopes.includes(requiredScope)) {
+            if (appPasswordError) {
+                if (appPasswordError.code === 'InvalidAuthScope') {
                     meta.result = 'fail';
-
+                    meta.source = 'asp';
                     await this.logAuthEvent(userData._id, meta);
-
-                    let err = new Error('Authentication failed. Invalid scope');
-                    err.responseCode = 403;
-                    err.code = 'InvalidAuthScope';
-                    err.response = 'NO'; // imap response code
-                    throw err;
                 }
-
-                // Everything checked out
-
-                meta.result = 'success';
-
-                let authEvent;
-                try {
-                    authEvent = await this.logAuthEvent(userData._id, meta);
-                } catch (err) {
-                    // don't really care
-                }
-
-                let aspUpdates = {
-                    used: now,
-                    authEvent,
-                    authIp: meta.ip
-                };
-
-                if (asp.ttl) {
-                    // extend temporary password ttl every time it is used
-                    aspUpdates.expires = new Date(now.getTime() + asp.ttl * 1000);
-                }
-
-                try {
-                    await this.users.collection('asps').updateOne(
-                        {
-                            _id: asp._id
-                        },
-                        {
-                            $set: aspUpdates
-                        },
-                        {
-                            maxTimeMS: consts.DB_MAX_TIME_USERS
-                        }
-                    );
-                } catch (err) {
-                    // ignore
-                }
-
-                const authResponse = {
-                    user: userData._id,
-                    username: userData.username,
-                    scope: requiredScope,
-                    asp: asp._id.toString(),
-                    require2fa: false // application scope never requires 2FA
-                };
-
-                return await authSuccess(authResponse);
+                throw appPasswordError;
             }
 
-            // no suitable password found
             meta.result = 'fail';
             meta.source = 'master';
             await this.logAuthEvent(userData._id, meta);
 
-            let err = new Error('Invalid Auth - Application-specific password did not match');
+            let err = new Error(appPasswordFailure);
             err.responseCode = 403;
             err.code = 'AuthFail'; // will be returned as failed auth, not an error
             throw err;

--- a/test/api/auth-rate-limit-test.js
+++ b/test/api/auth-rate-limit-test.js
@@ -23,9 +23,11 @@ describe('Authentication rate limits', function () {
     const address = `${username}@example.com`;
     const masterPassword = 'qrstuvwxyzabcdef';
     const appPassword = 'abcdefghijklmnop';
+    const scopeMismatchedPassword = 'ponmlkjihgfedcba';
 
     let userId;
     let rateLimitKey;
+    let scopeMismatchedAspId;
 
     before(async () => {
         await new Promise((resolve, reject) => db.connect(err => (err ? reject(err) : resolve())));
@@ -48,6 +50,26 @@ describe('Authentication rate limits', function () {
                 description: 'rate limit test',
                 scopes: ['imap'],
                 password: appPassword
+            })
+            .expect(200);
+
+        const scopeMismatchedResponse = await server
+            .post(`/users/${userId}/asps`)
+            .send({
+                description: 'scope mismatch test',
+                scopes: ['smtp'],
+                password: scopeMismatchedPassword
+            })
+            .expect(200);
+
+        scopeMismatchedAspId = scopeMismatchedResponse.body.id;
+
+        await server
+            .post(`/users/${userId}/asps`)
+            .send({
+                description: 'master password overlap test',
+                scopes: ['smtp'],
+                password: masterPassword
             })
             .expect(200);
 
@@ -99,10 +121,38 @@ describe('Authentication rate limits', function () {
             .send({
                 username: address,
                 password: masterPassword,
-                scope: 'imap'
+                scope: 'imap',
+                protocol: 'master-overlap-test'
             })
             .expect(200);
 
         expect(response.body.success).to.be.true;
+
+        const authlogResponse = await server.get(`/users/${userId}/authlog`).expect(200);
+        const masterAuthlogEntry = authlogResponse.body.results.find(entry => entry.source === 'master' && entry.result === 'success');
+
+        expect(masterAuthlogEntry).to.exist;
+        expect(masterAuthlogEntry.asp).to.not.exist;
+    });
+
+    it('should preserve ASP metadata when authentication fails because of its scope', async () => {
+        const response = await server
+            .post('/authenticate')
+            .send({
+                username: address,
+                password: scopeMismatchedPassword,
+                scope: 'imap'
+            })
+            .expect(403);
+
+        expect(response.body.code).to.equal('InvalidAuthScope');
+
+        const authlogResponse = await server.get(`/users/${userId}/authlog`).expect(200);
+        const authlogEntry = authlogResponse.body.results.find(entry => entry.asp === scopeMismatchedAspId);
+
+        expect(authlogEntry).to.exist;
+        expect(authlogEntry.source).to.equal('asp');
+        expect(authlogEntry.aname).to.equal('scope mismatch test');
+        expect(authlogEntry.result).to.equal('fail');
     });
 });

--- a/test/api/auth-rate-limit-test.js
+++ b/test/api/auth-rate-limit-test.js
@@ -1,0 +1,108 @@
+/*eslint no-unused-expressions: 0, prefer-arrow-callback: 0 */
+/* globals before: false, after: false */
+
+'use strict';
+
+const supertest = require('supertest');
+const chai = require('chai');
+
+const config = require('@zone-eu/wild-config');
+const consts = require('../../lib/consts');
+const db = require('../../lib/db');
+
+const expect = chai.expect;
+chai.config.includeStack = true;
+
+const server = supertest.agent(`http://127.0.0.1:${config.api.port}`);
+
+describe('Authentication rate limits', function () {
+    this.timeout(10000); // eslint-disable-line no-invalid-this
+
+    const suffix = `${process.pid}-${Date.now()}`;
+    const username = `auth-rate-limit-${suffix}`;
+    const address = `${username}@example.com`;
+    const masterPassword = 'qrstuvwxyzabcdef';
+    const appPassword = 'abcdefghijklmnop';
+
+    let userId;
+    let rateLimitKey;
+
+    before(async () => {
+        await new Promise((resolve, reject) => db.connect(err => (err ? reject(err) : resolve())));
+
+        const createResponse = await server
+            .post('/users')
+            .send({
+                username,
+                address,
+                password: masterPassword
+            })
+            .expect(200);
+
+        userId = createResponse.body.id;
+        rateLimitKey = `auth_user:${userId}`;
+
+        await server
+            .post(`/users/${userId}/asps`)
+            .send({
+                description: 'rate limit test',
+                scopes: ['imap'],
+                password: appPassword
+            })
+            .expect(200);
+
+        await db.redis.set(rateLimitKey, consts.USER_AUTH_FAILURES, 'EX', consts.USER_AUTH_WINDOW);
+    });
+
+    after(async () => {
+        if (rateLimitKey) {
+            await db.redis.del(rateLimitKey);
+        }
+
+        if (userId) {
+            await server.delete(`/users/${userId}`).expect(200);
+        }
+    });
+
+    it('should POST /authenticate expect success / using ASP while master password authentication is rate limited', async () => {
+        const response = await server
+            .post('/authenticate')
+            .send({
+                username: address,
+                password: appPassword,
+                scope: 'imap'
+            })
+            .expect(200);
+
+        expect(response.body.success).to.be.true;
+        expect(await db.redis.get(rateLimitKey)).to.equal(String(consts.USER_AUTH_FAILURES));
+    });
+
+    it('should POST /authenticate expect failure / using master password while account is rate limited', async () => {
+        const response = await server
+            .post('/authenticate')
+            .send({
+                username: address,
+                password: masterPassword,
+                scope: 'imap'
+            })
+            .expect(403);
+
+        expect(response.body.code).to.equal('RateLimitedError');
+    });
+
+    it('should POST /authenticate expect success / using master password after account rate limit is removed', async () => {
+        await db.redis.del(rateLimitKey);
+
+        const response = await server
+            .post('/authenticate')
+            .send({
+                username: address,
+                password: masterPassword,
+                scope: 'imap'
+            })
+            .expect(200);
+
+        expect(response.body.success).to.be.true;
+    });
+});


### PR DESCRIPTION
This PR fixes a situation where in case a user changes their master password and then the client bombards the server with the old master password the user will not be completely blocked from logging into their account.
Order of ratelimits:
1. Check ip ratelimit
2. Check asp ratelimit
3. Check account ratelimit (master password)

This ensures that even if master password login is ratelimited it is still possible to login at least with an ASP